### PR TITLE
Handle browser shutdown on connection failure, Fixes #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Handle browser process shutdown on 'Failed to connect to browser' @desoul99
+- Added configurable browser connection timeout and tries @desoul99
+
 ### Changed
 
 ### Removed

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -105,6 +105,9 @@ class Config:
         self.autodiscover_targets = True
         self.lang = lang
 
+        self.browser_connection_timeout = 0.25
+        self.browser_connection_max_tries = 10
+
         # other keyword args will be accessible by attribute
         self.__dict__.update(kwargs)
         super().__init__()


### PR DESCRIPTION
See #17 
Added configurable timeout and retries for the browser connection.
Added self.close() before throwing the "Failed to connect to browser" exception

I didn't test this thoroughly but the fixes are minor so I don't expect them to cause issues