### PR TITLE
Add remove handler method

### DIFF
--- a/tests/core/test_tab.py
+++ b/tests/core/test_tab.py
@@ -58,3 +58,79 @@ async def test_select(browser: zd.Browser):
     assert result is not None
     assert result.tag == "li"
     assert result.text == "Apples"
+
+
+async def test_add_handler_type_event(browser: zd.Browser):
+    tab = await browser.get(sample_file("groceries.html"))
+
+    async def request_handler_1(event):
+        pass
+
+    async def request_handler_2(event):
+        pass
+
+    assert len(tab.handlers) == 0
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_1)
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_2)
+
+    assert len(tab.handlers) == 1
+    assert len(tab.handlers[zd.cdp.network.RequestWillBeSent]) == 2
+    assert tab.handlers[zd.cdp.network.RequestWillBeSent] == [
+        request_handler_1,
+        request_handler_2,
+    ]
+
+
+async def test_add_hander_module_event(browser: zd.Browser):
+    tab = await browser.get(sample_file("groceries.html"))
+
+    async def request_handler(event):
+        pass
+
+    assert len(tab.handlers) == 0
+
+    tab.add_handler(zd.cdp.network, request_handler)
+
+    assert len(tab.handlers) == 26
+    assert tab.handlers[zd.cdp.network.RequestWillBeSent] == [request_handler]
+
+
+async def test_remove_handler(browser: zd.Browser):
+    tab = await browser.get(sample_file("groceries.html"))
+
+    async def request_handler(event):
+        pass
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler)
+
+    assert len(tab.handlers) == 1
+
+    tab.remove_handler(
+        zd.cdp.network.RequestWillBeSent,
+    )
+
+    assert len(tab.handlers) == 0
+
+
+async def test_remove_specific_handler(browser: zd.Browser):
+    tab = await browser.get(sample_file("groceries.html"))
+
+    async def request_handler_1(event):
+        pass
+
+    async def request_handler_2(event):
+        pass
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_1)
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_2)
+
+    assert len(tab.handlers) == 1
+    assert len(tab.handlers[zd.cdp.network.RequestWillBeSent]) == 2
+
+    tab.remove_handler(zd.cdp.network.RequestWillBeSent, request_handler_1)
+
+    assert len(tab.handlers) == 1
+    assert len(tab.handlers[zd.cdp.network.RequestWillBeSent]) == 1

--- a/tests/core/test_tab.py
+++ b/tests/core/test_tab.py
@@ -83,7 +83,7 @@ async def test_add_handler_type_event(browser: zd.Browser):
     ]
 
 
-async def test_add_hander_module_event(browser: zd.Browser):
+async def test_add_handler_module_event(browser: zd.Browser):
     tab = await browser.get(sample_file("groceries.html"))
 
     async def request_handler(event):
@@ -94,23 +94,33 @@ async def test_add_hander_module_event(browser: zd.Browser):
     tab.add_handler(zd.cdp.network, request_handler)
 
     assert len(tab.handlers) == 26
-    assert tab.handlers[zd.cdp.network.RequestWillBeSent] == [request_handler]
 
 
-async def test_remove_handler(browser: zd.Browser):
+async def test_remove_handlers(browser: zd.Browser):
     tab = await browser.get(sample_file("groceries.html"))
 
     async def request_handler(event):
         pass
 
     tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler)
-
     assert len(tab.handlers) == 1
 
-    tab.remove_handler(
+    tab.remove_handlers()
+    assert len(tab.handlers) == 0
+
+
+async def test_remove_handlers_specific_event(browser: zd.Browser):
+    tab = await browser.get(sample_file("groceries.html"))
+
+    async def request_handler(event):
+        pass
+
+    tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler)
+    assert len(tab.handlers) == 1
+
+    tab.remove_handlers(
         zd.cdp.network.RequestWillBeSent,
     )
-
     assert len(tab.handlers) == 0
 
 
@@ -124,13 +134,10 @@ async def test_remove_specific_handler(browser: zd.Browser):
         pass
 
     tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_1)
-
     tab.add_handler(zd.cdp.network.RequestWillBeSent, request_handler_2)
-
     assert len(tab.handlers) == 1
     assert len(tab.handlers[zd.cdp.network.RequestWillBeSent]) == 2
 
-    tab.remove_handler(zd.cdp.network.RequestWillBeSent, request_handler_1)
-
+    tab.remove_handlers(zd.cdp.network.RequestWillBeSent, request_handler_1)
     assert len(tab.handlers) == 1
     assert len(tab.handlers[zd.cdp.network.RequestWillBeSent]) == 1

--- a/zendriver/core/connection.py
+++ b/zendriver/core/connection.py
@@ -273,31 +273,39 @@ class Connection(metaclass=CantTouchThis):
         else:
             self.handlers[event_type_or_domain].append(handler)
 
-    def remove_handler(
+    def remove_handlers(
         self,
-        event_type: type,
+        event_type: Optional[type] = None,
         handler: Optional[Union[Callable, Awaitable]] = None,
     ):
         """
-        remove a handler for given event
+        remove handlers for given event
 
+        if no event is provided, all handlers will be removed.
         if no handler is provided, all handlers for the event will be removed.
 
         .. code-block::
 
-                page.remove_handler(cdp.network.RequestWillBeSent)
-                page.remove_handler(cdp.network.RequestWillBeSent, handler)
+                # remove all handlers for all events
+                page.remove_handlers()
+
+                # remove all handlers for a specific event
+                page.remove_handlers(cdp.network.RequestWillBeSent)
+
+                # remove a specific handler for a specific event
+                page.remove_handlers(cdp.network.RequestWillBeSent, handler)
         """
 
-        if handler is None:
-            self.handlers.pop(event_type)
+        if not event_type:
+            self.handlers.clear()
+            return
 
-        else:
-            try:
-                self.handlers[event_type].remove(handler)
+        if not handler:
+            del self.handlers[event_type]
+            return
 
-            except ValueError:
-                pass
+        if handler in self.handlers[event_type]:
+            self.handlers[event_type].remove(handler)
 
     async def aopen(self, **kw):
         """

--- a/zendriver/core/connection.py
+++ b/zendriver/core/connection.py
@@ -16,6 +16,7 @@ from typing import (
     Awaitable,
     Callable,
     Generator,
+    Optional,
     TypeVar,
     Union,
 )
@@ -268,8 +269,35 @@ class Connection(metaclass=CantTouchThis):
                 if inspect.isbuiltin(obj):
                     continue
                 self.handlers[obj].append(handler)
-            return
-        self.handlers[event_type_or_domain].append(handler)
+
+        else:
+            self.handlers[event_type_or_domain].append(handler)
+
+    def remove_handler(
+        self,
+        event_type: type,
+        handler: Optional[Union[Callable, Awaitable]] = None,
+    ):
+        """
+        remove a handler for given event
+
+        if no handler is provided, all handlers for the event will be removed.
+
+        .. code-block::
+
+                page.remove_handler(cdp.network.RequestWillBeSent)
+                page.remove_handler(cdp.network.RequestWillBeSent, handler)
+        """
+
+        if handler is None:
+            self.handlers.pop(event_type)
+
+        else:
+            try:
+                self.handlers[event_type].remove(handler)
+
+            except ValueError:
+                pass
 
     async def aopen(self, **kw):
         """


### PR DESCRIPTION
I needed the remove_handler ASAP, so I moved it to a separate request. I also wrote some unit tests for it. I didn’t handle the “module” parameter because I believe it’s unnecessary, even in add_handler. However, if someone thinks it’s useful, I can add it.

I’m not sure about the documentation, do we need to generate something for this?