### PR TITLE
Cleanup Temp Profiles On Stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `tab.remove_handlers` method for removing handlers @khamaileon
-- Cleanup temp profiles when `Browser.stop()` is called @barrycarey
+- Clean up temporary profiles when `Browser.stop()` is called @barrycarey
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `tab.remove_handlers` method for removing handlers @khamaileon
+- Cleanup temp profiles when `Browser.stop()` is called @barrycarey
 
 ### Changed
 

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -587,6 +587,7 @@ class Browser:
             await self._process.wait()
             self._process = None
             self._process_pid = None
+        await self._cleanup_temporary_profile()
 
     async def _cleanup_temporary_profile(self) -> None:
         if not self.config or self.config.uses_custom_data_dir:


### PR DESCRIPTION
Right now temp profiles are only cleaned up when the interrupter exits.  This PR simply calls the temp cleanup once Browser.stop() is finished, fixing #28 

This bug is problematic if you have a long running app that opens and closes browsers on a regular basis without ever restarting the interrupter. 