### PR TITLE
Resolve problems discovered while testing on macOS (fixes #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Test scripts improved for running on macOS @raycardillo
 
 ### Added
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 chrome_cmd+=("--version")
 
-chrome_version="${chrome_cmd[@]}"
+chrome_version=$("${chrome_cmd[@]}")
 echo "Chrome version: $chrome_version"
 
 set -x

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,7 +12,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   # macOS
   chrome_cmd=("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
 fi
-chrome_cmd+="--version"
+chrome_cmd+=("--version")
 
 chrome_version="${chrome_cmd[@]}"
 echo "Chrome version: $chrome_version"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,14 @@ if [ "${#command[@]}" -eq 0 ]; then
   command=( "pytest" )
 fi
 
-chrome_version=$(google-chrome --version)
+chrome_cmd=("google-chrome")
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS
+  chrome_cmd=("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+fi
+chrome_cmd+="--version"
+
+chrome_version="${chrome_cmd[@]}"
 echo "Chrome version: $chrome_version"
 
 set -x

--- a/tests/bot_detection/test_browserscan.py
+++ b/tests/bot_detection/test_browserscan.py
@@ -4,6 +4,9 @@ import zendriver as zd
 async def test_browserscan(browser: zd.Browser):
     page = await browser.get("https://www.browserscan.net/bot-detection")
 
+    # give the javascript some time to finish executing
+    await page.wait(2)
+
     element = await page.find_element_by_text("Test Results:")
     assert (
         element is not None


### PR DESCRIPTION
This PR resolves two issues I found when testing on macOS. See issue #58 for details.

1. Updates to the `scripts/test.sh` so that it will work "out of the box" on macOS. I did this in a way that should not interfere with existing users and provides the pattern for solving the same problem if it might arise on other platforms in the future.
2. The test in `tests/bot_detection/test_browserscan.py` does not wait long enough for the javascript to render the element in the DOM that the test is looking for. I added a small `page.wait()` that resolves this and now the tests pass consistently.
