### PR TITLE
Ignore irrelevant DOM.disable errors. (fixes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Ignore irrelevant `DOM.disable` errors @raycardillo
 
 ### Added
 


### PR DESCRIPTION
See issue #61 for more details. This PR has the following changes.

- Introduces the `disable_dom_agent()` utility method to help ignore and log any `ProtocolException` that happens. The only time I've seen this command fail is when the DOM is already disabled. If that is thrown when there isn't any other problem, it causes more problems, when nothing is actually wrong.
- Updated all of the calls to the `DOM.disable` command to use this helper instead.
- Updated a couple log lines that were not formatted like the others (missing a colon).