### PR TITLE
Config fixes required to support multiple browsers. (fixes #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Multiple Browsers can be created without one affecting the other @raycardillo
+
 ### Added
 
 ### Changed

--- a/tests/bot_detection/test_browserscan.py
+++ b/tests/bot_detection/test_browserscan.py
@@ -4,6 +4,9 @@ import zendriver as zd
 async def test_browserscan(browser: zd.Browser):
     page = await browser.get("https://www.browserscan.net/bot-detection")
 
+    # wait for the page to fully load
+    await page.wait_for_ready_state("complete")
+
     # give the javascript some time to finish executing
     await page.wait(2)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ async def browser(request: pytest.FixtureRequest) -> AsyncGenerator[zd.Browser, 
     )
     browser_pid = browser._process_pid
     assert browser_pid is not None and browser_pid > 0
+    await browser.wait(0)
     yield browser
     if PAUSE_AFTER_TEST:
         logger.info(

--- a/tests/core/test_multiple_browsers.py
+++ b/tests/core/test_multiple_browsers.py
@@ -1,0 +1,57 @@
+import zendriver as zd
+
+
+# browser fixture not used here because this is a special case
+
+
+async def test_multiple_browsers_diff_userdata():
+    config = zd.Config(
+        headless=True,
+        browser_args=[
+            "--enable-features=UseOzonePlatform",
+            "--ozone-platform=wayland",
+            "--window-size=800,800",
+            "--wait-for-debugger-webui",
+        ],
+    )
+    config.browser_connection_timeout = 1
+    config.browser_connection_max_tries = 15
+
+    browser1 = await zd.start(config)
+    browser2 = await zd.start(config)
+    browser3 = await zd.start(config)
+
+    assert not browser1.config.uses_custom_data_dir
+    assert not browser2.config.uses_custom_data_dir
+    assert not browser3.config.uses_custom_data_dir
+
+    # make sure ports are unique
+    ports = {browser1.config.port, browser2.config.port, browser3.config.port}
+    assert len(ports) == 3
+
+    # make sure user data dirs are unique
+    udds = {
+        browser1.config.user_data_dir,
+        browser2.config.user_data_dir,
+        browser3.config.user_data_dir,
+    }
+    assert len(udds) == 3
+
+    page1 = await browser1.get("https://example.com/one")
+    await page1
+    assert page1.target
+    assert page1.target.title == "Example Domain"
+
+    page2 = await browser2.get("https://example.com/two")
+    await page2
+    assert page2.target
+    assert page2.target.title == "Example Domain"
+
+    page3 = await browser3.get("https://example.com/three")
+    await page3
+    assert page3.target
+    assert page3.target.title == "Example Domain"
+
+    await browser1.stop()
+    await browser2.stop()
+    await browser3.stop()


### PR DESCRIPTION
## Description

See #60. While the primary motivation was to support multiple browsers, I consider everything here more of a "bug fix" than "enhancement" because the root cause was related to the Browser corrupting the Config it was passed. While testing, I also discovered and resolved some dead code and other minor problems.

Here are the highlights:
- Browser copies Config so it has it's own copy to use for host, port, user data, etc.
- Config defers creation of a temporary directory. Otherwise, the main config (e.g., the original copy being used as a template) would end up having the same directory. Also discovered that Chrome does not even like that (second instance using the same user data dir cannot connect).
- Fixed an intermittent `ProcessLookupError` that took me way too long to diagnose while running the test suite (it's apparently a [well known issue](https://github.com/python/cpython/issues/84730)).
- Added a new test for multiple browsers and fixed some small race conditions.

p.s., The Config user data refactoring was influenced by type problems that the linter caught. So I had to declare `_user_data_dir` early in `__init__` and make sure the types aligned throughout.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
