### PR TITLE
Use `about:blank` as default and executable target (fixes #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default and launch changed to use `about:blank` (faster start and less bandwidth) @raycardillo
+
 ### Removed
 
 ## [0.4.1] - 2025-02-09

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -240,7 +240,7 @@ class Browser:
             self.targets.remove(current_tab)
 
     async def get(
-        self, url="chrome://welcome", new_tab: bool = False, new_window: bool = False
+        self, url="about:blank", new_tab: bool = False, new_window: bool = False
     ) -> tab.Tab:
         """top level get. utilizes the first tab to retrieve given url.
 
@@ -331,6 +331,7 @@ class Browser:
 
         exe = self.config.browser_executable_path
         params = self.config()
+        params.append("about:blank")
 
         logger.info(
             "starting\n\texecutable :%s\n\narguments:\n%s", exe, "\n\t".join(params)

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -341,7 +341,7 @@ class Tab(Connection):
         return items
 
     async def get(
-        self, url="chrome://welcome", new_tab: bool = False, new_window: bool = False
+        self, url="about:blank", new_tab: bool = False, new_window: bool = False
     ):
         """top level get. utilizes the first tab to retrieve given url.
 


### PR DESCRIPTION
## Description

This is a fairly small change with a really good improvement. 😃 The `chrome://welcome` page takes longer to load and uses some bandwidth to do some "google things" behind the scenes. The `about:blank` does none of that.

So there are just two things in this PR but the benefits are fairly significant:
- `about:blank` is the default instead of `chrome://welcome`
- The executable is launched with `about:blank` as the last param so the initial launch and start time is faster. Since it doesn't load all the things the welcome page does, it also uses less/no bandwidth per launch.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
