### PR TITLE
Defend browser.stop() against Chrome freezing or hanging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improvements to avoid browser.stop() from causing deadlock or hanging @raycardillo
+
 ### Added
 
 ### Changed

--- a/zendriver/core/connection.py
+++ b/zendriver/core/connection.py
@@ -117,12 +117,14 @@ class Transaction(asyncio.Future):
         if "error" in response:
             # set exception and bail out
             return self.set_exception(ProtocolException(response["error"]))
+        
         try:
             # try to parse the result according to the py cdp docs.
             self.__cdp_obj__.send(response["result"])
         except StopIteration as e:
             # exception value holds the parsed response
             return self.set_result(e.value)
+            
         raise ProtocolException("could not parse the cdp response:\n%s" % response)
 
     def __repr__(self):
@@ -447,7 +449,7 @@ class Connection(metaclass=CantTouchThis):
         :param cdp_obj: the generator object created by a cdp method
 
         :param _is_update: internal flag
-            prevents infinite loop by skipping the registeration of handlers
+            prevents infinite loop by skipping the registration of handlers
             when multiple calls to connection.send() are made
         :return:
         """
@@ -585,7 +587,7 @@ class Connection(metaclass=CantTouchThis):
         self.mapper.update({tx.id: tx})
         await self.websocket.send(tx.message)
         try:
-            # in try except since if browser connection sends this it reises an exception
+            # in try except since if browser connection sends this it raises an exception
             return await tx
         except ProtocolException:
             pass
@@ -650,7 +652,7 @@ class Listener:
             except asyncio.TimeoutError:
                 self.idle.set()
                 # breathe
-                # await asyncio.sleep(self.time_before_considered_idle / 10)
+                await asyncio.sleep(0)
                 continue
             except asyncio.CancelledError:
                 logger.debug(

--- a/zendriver/core/util.py
+++ b/zendriver/core/util.py
@@ -326,21 +326,3 @@ def cdp_get_module(domain: Union[str, types.ModuleType]):
                     "could not find cdp module from input '%s'" % domain
                 )
     return domain_mod
-
-
-async def _read_process_stderr(
-    process: asyncio.subprocess.Process, n: int = 2**16
-) -> str:
-    """
-    Read the given number of bytes from the stderr of the given process.
-
-    Read bytes are automatically decoded to utf-8.
-    """
-    if process.stderr is None:
-        raise ValueError("Process has no stderr")
-
-    try:
-        return (await asyncio.wait_for(process.stderr.read(n), 0.25)).decode("utf-8")
-    except asyncio.TimeoutError:
-        logger.debug("Timeout reading process stderr")
-        return ""


### PR DESCRIPTION
## Description

While testing under load (heavy scraping job with many browsers running in parallel) I've been digging into problems where Chrome becomes non-responsive and it causes the entire job to hang forever.

After a bunch of research and debugging, I fixed several problems I found, but I think the most significant was the way th process `stderr` was being read. The [subprocess documentation](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.stderr) specifically warns not to use `read()`, `wait()` if you want to avoid a potential deadlock, which is exactly what was happening to me.

WORK IN PROGRESS - DO NOT MERGE - WILL UPDATE AFTER VERIFICATION IN PRODUCTION

Because of the nature of this problem, I don't have a test case to contribute. However, if you look at the proposed changes, they are all valid improvements and some are defensive coding.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
