### PR TITLE
Update CDP models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated CDP models @jsuarezl
 
 ### Removed
 

--- a/zendriver/cdp/__init__.py
+++ b/zendriver/cdp/__init__.py
@@ -19,7 +19,6 @@ from . import (
     dom_debugger,
     dom_snapshot,
     dom_storage,
-    database,
     debugger,
     device_access,
     device_orientation,

--- a/zendriver/cdp/browser.py
+++ b/zendriver/cdp/browser.py
@@ -108,35 +108,42 @@ class Bounds:
 
 
 class PermissionType(enum.Enum):
-    ACCESSIBILITY_EVENTS = "accessibilityEvents"
+    AR = "ar"
     AUDIO_CAPTURE = "audioCapture"
-    BACKGROUND_SYNC = "backgroundSync"
+    AUTOMATIC_FULLSCREEN = "automaticFullscreen"
     BACKGROUND_FETCH = "backgroundFetch"
+    BACKGROUND_SYNC = "backgroundSync"
+    CAMERA_PAN_TILT_ZOOM = "cameraPanTiltZoom"
     CAPTURED_SURFACE_CONTROL = "capturedSurfaceControl"
     CLIPBOARD_READ_WRITE = "clipboardReadWrite"
     CLIPBOARD_SANITIZED_WRITE = "clipboardSanitizedWrite"
     DISPLAY_CAPTURE = "displayCapture"
     DURABLE_STORAGE = "durableStorage"
-    FLASH = "flash"
     GEOLOCATION = "geolocation"
+    HAND_TRACKING = "handTracking"
     IDLE_DETECTION = "idleDetection"
+    KEYBOARD_LOCK = "keyboardLock"
     LOCAL_FONTS = "localFonts"
+    LOCAL_NETWORK_ACCESS = "localNetworkAccess"
     MIDI = "midi"
     MIDI_SYSEX = "midiSysex"
     NFC = "nfc"
     NOTIFICATIONS = "notifications"
     PAYMENT_HANDLER = "paymentHandler"
     PERIODIC_BACKGROUND_SYNC = "periodicBackgroundSync"
+    POINTER_LOCK = "pointerLock"
     PROTECTED_MEDIA_IDENTIFIER = "protectedMediaIdentifier"
     SENSORS = "sensors"
-    STORAGE_ACCESS = "storageAccess"
+    SMART_CARD = "smartCard"
     SPEAKER_SELECTION = "speakerSelection"
+    STORAGE_ACCESS = "storageAccess"
     TOP_LEVEL_STORAGE_ACCESS = "topLevelStorageAccess"
     VIDEO_CAPTURE = "videoCapture"
-    VIDEO_CAPTURE_PAN_TILT_ZOOM = "videoCapturePanTiltZoom"
+    VR = "vr"
     WAKE_LOCK_SCREEN = "wakeLockScreen"
     WAKE_LOCK_SYSTEM = "wakeLockSystem"
     WEB_APP_INSTALLATION = "webAppInstallation"
+    WEB_PRINTING = "webPrinting"
     WINDOW_MANAGEMENT = "windowManagement"
 
     def to_json(self) -> str:
@@ -229,6 +236,7 @@ class BrowserCommandId(enum.Enum):
 
     OPEN_TAB_SEARCH = "openTabSearch"
     CLOSE_TAB_SEARCH = "closeTabSearch"
+    OPEN_GLIC = "openGlic"
 
     def to_json(self) -> str:
         return self.value
@@ -303,6 +311,18 @@ class Histogram:
             count=int(json["count"]),
             buckets=[Bucket.from_json(i) for i in json["buckets"]],
         )
+
+
+class PrivacySandboxAPI(enum.Enum):
+    BIDDING_AND_AUCTION_SERVICES = "BiddingAndAuctionServices"
+    TRUSTED_KEY_VALUE = "TrustedKeyValue"
+
+    def to_json(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_json(cls, json: str) -> PrivacySandboxAPI:
+        return cls(json)
 
 
 def set_permission(
@@ -467,9 +487,9 @@ def crash_gpu_process() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     json = yield cmd_dict
 
 
-def get_version() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, str, str, str, str]]
-):
+def get_version() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, str, str, str, str]
+]:
     """
     Returns version information.
 
@@ -494,9 +514,9 @@ def get_version() -> (
     )
 
 
-def get_browser_command_line() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]
-):
+def get_browser_command_line() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[str]
+]:
     """
     Returns the command line switches for the browser process if, and only if
     --enable-automation is on the commandline.
@@ -683,6 +703,36 @@ def add_privacy_sandbox_enrollment_override(
     params["url"] = url
     cmd_dict: T_JSON_DICT = {
         "method": "Browser.addPrivacySandboxEnrollmentOverride",
+        "params": params,
+    }
+    json = yield cmd_dict
+
+
+def add_privacy_sandbox_coordinator_key_config(
+    api: PrivacySandboxAPI,
+    coordinator_origin: str,
+    key_config: str,
+    browser_context_id: typing.Optional[BrowserContextID] = None,
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    """
+    Configures encryption keys used with a given privacy sandbox API to talk
+    to a trusted coordinator.  Since this is intended for test automation only,
+    coordinatorOrigin must be a .test domain. No existing coordinator
+    configuration for the origin may exist.
+
+    :param api:
+    :param coordinator_origin:
+    :param key_config:
+    :param browser_context_id: *(Optional)* BrowserContext to perform the action in. When omitted, default browser context is used.
+    """
+    params: T_JSON_DICT = dict()
+    params["api"] = api.to_json()
+    params["coordinatorOrigin"] = coordinator_origin
+    params["keyConfig"] = key_config
+    if browser_context_id is not None:
+        params["browserContextId"] = browser_context_id.to_json()
+    cmd_dict: T_JSON_DICT = {
+        "method": "Browser.addPrivacySandboxCoordinatorKeyConfig",
         "params": params,
     }
     json = yield cmd_dict

--- a/zendriver/cdp/css.py
+++ b/zendriver/cdp/css.py
@@ -82,6 +82,33 @@ class PseudoElementMatches:
 
 
 @dataclass
+class CSSAnimationStyle:
+    """
+    CSS style coming from animations with the name of the animation.
+    """
+
+    #: The style coming from the animation.
+    style: CSSStyle
+
+    #: The name of the animation.
+    name: typing.Optional[str] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["style"] = self.style.to_json()
+        if self.name is not None:
+            json["name"] = self.name
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> CSSAnimationStyle:
+        return cls(
+            style=CSSStyle.from_json(json["style"]),
+            name=str(json["name"]) if json.get("name", None) is not None else None,
+        )
+
+
+@dataclass
 class InheritedStyleEntry:
     """
     Inherited CSS rule collection from ancestor node.
@@ -106,6 +133,40 @@ class InheritedStyleEntry:
             matched_css_rules=[RuleMatch.from_json(i) for i in json["matchedCSSRules"]],
             inline_style=CSSStyle.from_json(json["inlineStyle"])
             if json.get("inlineStyle", None) is not None
+            else None,
+        )
+
+
+@dataclass
+class InheritedAnimatedStyleEntry:
+    """
+    Inherited CSS style collection for animated styles from ancestor node.
+    """
+
+    #: Styles coming from the animations of the ancestor, if any, in the style inheritance chain.
+    animation_styles: typing.Optional[typing.List[CSSAnimationStyle]] = None
+
+    #: The style coming from the transitions of the ancestor, if any, in the style inheritance chain.
+    transitions_style: typing.Optional[CSSStyle] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        if self.animation_styles is not None:
+            json["animationStyles"] = [i.to_json() for i in self.animation_styles]
+        if self.transitions_style is not None:
+            json["transitionsStyle"] = self.transitions_style.to_json()
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> InheritedAnimatedStyleEntry:
+        return cls(
+            animation_styles=[
+                CSSAnimationStyle.from_json(i) for i in json["animationStyles"]
+            ]
+            if json.get("animationStyles", None) is not None
+            else None,
+            transitions_style=CSSStyle.from_json(json["transitionsStyle"])
+            if json.get("transitionsStyle", None) is not None
             else None,
         )
 
@@ -1539,6 +1600,159 @@ class CSSPropertyRule:
 
 
 @dataclass
+class CSSFunctionParameter:
+    """
+    CSS function argument representation.
+    """
+
+    #: The parameter name.
+    name: str
+
+    #: The parameter type.
+    type_: str
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["name"] = self.name
+        json["type"] = self.type_
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> CSSFunctionParameter:
+        return cls(
+            name=str(json["name"]),
+            type_=str(json["type"]),
+        )
+
+
+@dataclass
+class CSSFunctionConditionNode:
+    """
+    CSS function conditional block representation.
+    """
+
+    #: Block body.
+    children: typing.List[CSSFunctionNode]
+
+    #: The condition text.
+    condition_text: str
+
+    #: Media query for this conditional block. Only one type of condition should be set.
+    media: typing.Optional[CSSMedia] = None
+
+    #: Container query for this conditional block. Only one type of condition should be set.
+    container_queries: typing.Optional[CSSContainerQuery] = None
+
+    #: @supports CSS at-rule condition. Only one type of condition should be set.
+    supports: typing.Optional[CSSSupports] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["children"] = [i.to_json() for i in self.children]
+        json["conditionText"] = self.condition_text
+        if self.media is not None:
+            json["media"] = self.media.to_json()
+        if self.container_queries is not None:
+            json["containerQueries"] = self.container_queries.to_json()
+        if self.supports is not None:
+            json["supports"] = self.supports.to_json()
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> CSSFunctionConditionNode:
+        return cls(
+            children=[CSSFunctionNode.from_json(i) for i in json["children"]],
+            condition_text=str(json["conditionText"]),
+            media=CSSMedia.from_json(json["media"])
+            if json.get("media", None) is not None
+            else None,
+            container_queries=CSSContainerQuery.from_json(json["containerQueries"])
+            if json.get("containerQueries", None) is not None
+            else None,
+            supports=CSSSupports.from_json(json["supports"])
+            if json.get("supports", None) is not None
+            else None,
+        )
+
+
+@dataclass
+class CSSFunctionNode:
+    """
+    Section of the body of a CSS function rule.
+    """
+
+    #: A conditional block. If set, style should not be set.
+    condition: typing.Optional[CSSFunctionConditionNode] = None
+
+    #: Values set by this node. If set, condition should not be set.
+    style: typing.Optional[CSSStyle] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        if self.condition is not None:
+            json["condition"] = self.condition.to_json()
+        if self.style is not None:
+            json["style"] = self.style.to_json()
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> CSSFunctionNode:
+        return cls(
+            condition=CSSFunctionConditionNode.from_json(json["condition"])
+            if json.get("condition", None) is not None
+            else None,
+            style=CSSStyle.from_json(json["style"])
+            if json.get("style", None) is not None
+            else None,
+        )
+
+
+@dataclass
+class CSSFunctionRule:
+    """
+    CSS function at-rule representation.
+    """
+
+    #: Name of the function.
+    name: Value
+
+    #: Parent stylesheet's origin.
+    origin: StyleSheetOrigin
+
+    #: List of parameters.
+    parameters: typing.List[CSSFunctionParameter]
+
+    #: Function body.
+    children: typing.List[CSSFunctionNode]
+
+    #: The css style sheet identifier (absent for user agent stylesheet and user-specified
+    #: stylesheet rules) this rule came from.
+    style_sheet_id: typing.Optional[StyleSheetId] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["name"] = self.name.to_json()
+        json["origin"] = self.origin.to_json()
+        json["parameters"] = [i.to_json() for i in self.parameters]
+        json["children"] = [i.to_json() for i in self.children]
+        if self.style_sheet_id is not None:
+            json["styleSheetId"] = self.style_sheet_id.to_json()
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> CSSFunctionRule:
+        return cls(
+            name=Value.from_json(json["name"]),
+            origin=StyleSheetOrigin.from_json(json["origin"]),
+            parameters=[CSSFunctionParameter.from_json(i) for i in json["parameters"]],
+            children=[CSSFunctionNode.from_json(i) for i in json["children"]],
+            style_sheet_id=StyleSheetId.from_json(json["styleSheetId"])
+            if json.get("styleSheetId", None) is not None
+            else None,
+        )
+
+
+@dataclass
 class CSSKeyframeRule:
     """
     CSS keyframe rule representation.
@@ -1661,16 +1875,19 @@ def collect_class_names(
 
 
 def create_style_sheet(
-    frame_id: page.FrameId,
+    frame_id: page.FrameId, force: typing.Optional[bool] = None
 ) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, StyleSheetId]:
     """
     Creates a new special "via-inspector" stylesheet in the frame with given ``frameId``.
 
     :param frame_id: Identifier of the frame where "via-inspector" stylesheet should be created.
+    :param force: *(Optional)* If true, creates a new stylesheet for every call. If false, returns a stylesheet previously created by a call with force=false for the frame's document if it exists or creates a new stylesheet (default: false).
     :returns: Identifier of the created "via-inspector" stylesheet.
     """
     params: T_JSON_DICT = dict()
     params["frameId"] = frame_id.to_json()
+    if force is not None:
+        params["force"] = force
     cmd_dict: T_JSON_DICT = {
         "method": "CSS.createStyleSheet",
         "params": params,
@@ -1715,6 +1932,25 @@ def force_pseudo_state(
     params["forcedPseudoClasses"] = [i for i in forced_pseudo_classes]
     cmd_dict: T_JSON_DICT = {
         "method": "CSS.forcePseudoState",
+        "params": params,
+    }
+    json = yield cmd_dict
+
+
+def force_starting_style(
+    node_id: dom.NodeId, forced: bool
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    """
+    Ensures that the given node is in its starting-style state.
+
+    :param node_id: The element id for which to force the starting-style state.
+    :param forced: Boolean indicating if this is on or off.
+    """
+    params: T_JSON_DICT = dict()
+    params["nodeId"] = node_id.to_json()
+    params["forced"] = forced
+    cmd_dict: T_JSON_DICT = {
+        "method": "CSS.forceStartingStyle",
         "params": params,
     }
     json = yield cmd_dict
@@ -1776,6 +2012,73 @@ def get_computed_style_for_node(
     return [CSSComputedStyleProperty.from_json(i) for i in json["computedStyle"]]
 
 
+def resolve_values(
+    values: typing.List[str],
+    node_id: dom.NodeId,
+    property_name: typing.Optional[str] = None,
+    pseudo_type: typing.Optional[dom.PseudoType] = None,
+    pseudo_identifier: typing.Optional[str] = None,
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+    """
+    Resolve the specified values in the context of the provided element.
+    For example, a value of '1em' is evaluated according to the computed
+    'font-size' of the element and a value 'calc(1px + 2px)' will be
+    resolved to '3px'.
+    If the ``propertyName`` was specified the ``values`` are resolved as if
+    they were property's declaration. If a value cannot be parsed according
+    to the provided property syntax, the value is parsed using combined
+    syntax as if null ``propertyName`` was provided. If the value cannot be
+    resolved even then, return the provided value without any changes.
+
+    **EXPERIMENTAL**
+
+    :param values: Substitution functions (var()/env()/attr()) and cascade-dependent keywords (revert/revert-layer) do not work.
+    :param node_id: Id of the node in whose context the expression is evaluated
+    :param property_name: *(Optional)* Only longhands and custom property names are accepted.
+    :param pseudo_type: *(Optional)* Pseudo element type, only works for pseudo elements that generate elements in the tree, such as ::before and ::after.
+    :param pseudo_identifier: *(Optional)* Pseudo element custom ident.
+    :returns:
+    """
+    params: T_JSON_DICT = dict()
+    params["values"] = [i for i in values]
+    params["nodeId"] = node_id.to_json()
+    if property_name is not None:
+        params["propertyName"] = property_name
+    if pseudo_type is not None:
+        params["pseudoType"] = pseudo_type.to_json()
+    if pseudo_identifier is not None:
+        params["pseudoIdentifier"] = pseudo_identifier
+    cmd_dict: T_JSON_DICT = {
+        "method": "CSS.resolveValues",
+        "params": params,
+    }
+    json = yield cmd_dict
+    return [str(i) for i in json["results"]]
+
+
+def get_longhand_properties(
+    shorthand_name: str, value: str
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[CSSProperty]]:
+    """
+
+
+    **EXPERIMENTAL**
+
+    :param shorthand_name:
+    :param value:
+    :returns:
+    """
+    params: T_JSON_DICT = dict()
+    params["shorthandName"] = shorthand_name
+    params["value"] = value
+    cmd_dict: T_JSON_DICT = {
+        "method": "CSS.getLonghandProperties",
+        "params": params,
+    }
+    json = yield cmd_dict
+    return [CSSProperty.from_json(i) for i in json["longhandProperties"]]
+
+
 def get_inline_styles_for_node(
     node_id: dom.NodeId,
 ) -> typing.Generator[
@@ -1810,6 +2113,50 @@ def get_inline_styles_for_node(
     )
 
 
+def get_animated_styles_for_node(
+    node_id: dom.NodeId,
+) -> typing.Generator[
+    T_JSON_DICT,
+    T_JSON_DICT,
+    typing.Tuple[
+        typing.Optional[typing.List[CSSAnimationStyle]],
+        typing.Optional[CSSStyle],
+        typing.Optional[typing.List[InheritedAnimatedStyleEntry]],
+    ],
+]:
+    """
+    Returns the styles coming from animations & transitions
+    including the animation & transition styles coming from inheritance chain.
+
+    **EXPERIMENTAL**
+
+    :param node_id:
+    :returns: A tuple with the following items:
+
+        0. **animationStyles** - *(Optional)* Styles coming from animations.
+        1. **transitionsStyle** - *(Optional)* Style coming from transitions.
+        2. **inherited** - *(Optional)* Inherited style entries for animationsStyle and transitionsStyle from the inheritance chain of the element.
+    """
+    params: T_JSON_DICT = dict()
+    params["nodeId"] = node_id.to_json()
+    cmd_dict: T_JSON_DICT = {
+        "method": "CSS.getAnimatedStylesForNode",
+        "params": params,
+    }
+    json = yield cmd_dict
+    return (
+        [CSSAnimationStyle.from_json(i) for i in json["animationStyles"]]
+        if json.get("animationStyles", None) is not None
+        else None,
+        CSSStyle.from_json(json["transitionsStyle"])
+        if json.get("transitionsStyle", None) is not None
+        else None,
+        [InheritedAnimatedStyleEntry.from_json(i) for i in json["inherited"]]
+        if json.get("inherited", None) is not None
+        else None,
+    )
+
+
 def get_matched_styles_for_node(
     node_id: dom.NodeId,
 ) -> typing.Generator[
@@ -1829,6 +2176,7 @@ def get_matched_styles_for_node(
         typing.Optional[typing.List[CSSPropertyRegistration]],
         typing.Optional[CSSFontPaletteValuesRule],
         typing.Optional[dom.NodeId],
+        typing.Optional[typing.List[CSSFunctionRule]],
     ],
 ]:
     """
@@ -1850,6 +2198,7 @@ def get_matched_styles_for_node(
         10. **cssPropertyRegistrations** - *(Optional)* A list of CSS property registrations matching this node.
         11. **cssFontPaletteValuesRule** - *(Optional)* A font-palette-values rule matching this node.
         12. **parentLayoutNodeId** - *(Optional)* Id of the first parent element that does not have display: contents.
+        13. **cssFunctionRules** - *(Optional)* A list of CSS at-function rules referenced by styles of this node.
     """
     params: T_JSON_DICT = dict()
     params["nodeId"] = node_id.to_json()
@@ -1901,12 +2250,15 @@ def get_matched_styles_for_node(
         dom.NodeId.from_json(json["parentLayoutNodeId"])
         if json.get("parentLayoutNodeId", None) is not None
         else None,
+        [CSSFunctionRule.from_json(i) for i in json["cssFunctionRules"]]
+        if json.get("cssFunctionRules", None) is not None
+        else None,
     )
 
 
-def get_media_queries() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[CSSMedia]]
-):
+def get_media_queries() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[CSSMedia]
+]:
     """
     Returns all media queries parsed by the rendering engine.
 
@@ -2055,9 +2407,9 @@ def track_computed_style_updates(
     json = yield cmd_dict
 
 
-def take_computed_style_updates() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[dom.NodeId]]
-):
+def take_computed_style_updates() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[dom.NodeId]
+]:
     """
     Polls the next batch of computed style updates.
 
@@ -2321,9 +2673,9 @@ def start_rule_usage_tracking() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, No
     json = yield cmd_dict
 
 
-def stop_rule_usage_tracking() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[RuleUsage]]
-):
+def stop_rule_usage_tracking() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[RuleUsage]
+]:
     """
     Stop tracking rule usage and return the list of rules that were used since last call to
     ``takeCoverageDelta`` (or since start of coverage instrumentation).
@@ -2337,11 +2689,9 @@ def stop_rule_usage_tracking() -> (
     return [RuleUsage.from_json(i) for i in json["ruleUsage"]]
 
 
-def take_coverage_delta() -> (
-    typing.Generator[
-        T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[RuleUsage], float]
-    ]
-):
+def take_coverage_delta() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[RuleUsage], float]
+]:
     """
     Obtain list of rules that became used since last call to this method (or since start of coverage
     instrumentation).

--- a/zendriver/cdp/device_orientation.py
+++ b/zendriver/cdp/device_orientation.py
@@ -12,9 +12,9 @@ from dataclasses import dataclass
 from .util import event_class, T_JSON_DICT
 
 
-def clear_device_orientation_override() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, None]
-):
+def clear_device_orientation_override() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, None
+]:
     """
     Clears the overridden Device Orientation.
     """

--- a/zendriver/cdp/dom.py
+++ b/zendriver/cdp/dom.py
@@ -86,10 +86,10 @@ class PseudoType(enum.Enum):
 
     FIRST_LINE = "first-line"
     FIRST_LETTER = "first-letter"
-    CHECK = "check"
+    CHECKMARK = "checkmark"
     BEFORE = "before"
     AFTER = "after"
-    SELECT_ARROW = "select-arrow"
+    PICKER_ICON = "picker-icon"
     MARKER = "marker"
     BACKDROP = "backdrop"
     COLUMN = "column"
@@ -102,8 +102,7 @@ class PseudoType(enum.Enum):
     FIRST_LINE_INHERITED = "first-line-inherited"
     SCROLL_MARKER = "scroll-marker"
     SCROLL_MARKER_GROUP = "scroll-marker-group"
-    SCROLL_NEXT_BUTTON = "scroll-next-button"
-    SCROLL_PREV_BUTTON = "scroll-prev-button"
+    SCROLL_BUTTON = "scroll-button"
     SCROLLBAR = "scrollbar"
     SCROLLBAR_THUMB = "scrollbar-thumb"
     SCROLLBAR_BUTTON = "scrollbar-button"
@@ -1338,9 +1337,9 @@ def query_selector_all(
     return [NodeId.from_json(i) for i in json["nodeIds"]]
 
 
-def get_top_layer_elements() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]
-):
+def get_top_layer_elements() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]
+]:
     """
     Returns NodeIds of current top layer elements.
     Top layer is rendered closest to the user within a viewport, therefore its elements always
@@ -1645,9 +1644,9 @@ def get_file_info(
     return str(json["path"])
 
 
-def get_detached_dom_nodes() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[DetachedElementInfo]]
-):
+def get_detached_dom_nodes() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[DetachedElementInfo]
+]:
     """
     Returns list of detached nodes
 

--- a/zendriver/cdp/extensions.py
+++ b/zendriver/cdp/extensions.py
@@ -51,6 +51,23 @@ def load_unpacked(path: str) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
     return str(json["id"])
 
 
+def uninstall(id_: str) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    """
+    Uninstalls an unpacked extension (others not supported) from the profile.
+    Available if the client is connected using the --remote-debugging-pipe flag
+    and the --enable-unsafe-extension-debugging.
+
+    :param id_: Extension id.
+    """
+    params: T_JSON_DICT = dict()
+    params["id"] = id_
+    cmd_dict: T_JSON_DICT = {
+        "method": "Extensions.uninstall",
+        "params": params,
+    }
+    json = yield cmd_dict
+
+
 def get_storage_items(
     id_: str, storage_area: StorageArea, keys: typing.Optional[typing.List[str]] = None
 ) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, dict]:

--- a/zendriver/cdp/heap_profiler.py
+++ b/zendriver/cdp/heap_profiler.py
@@ -198,9 +198,9 @@ def get_object_by_heap_object_id(
     return runtime.RemoteObject.from_json(json["result"])
 
 
-def get_sampling_profile() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, SamplingHeapProfile]
-):
+def get_sampling_profile() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, SamplingHeapProfile
+]:
     """
 
 

--- a/zendriver/cdp/memory.py
+++ b/zendriver/cdp/memory.py
@@ -147,9 +147,9 @@ class DOMCounter:
         )
 
 
-def get_dom_counters() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[int, int, int]]
-):
+def get_dom_counters() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[int, int, int]
+]:
     """
     Retruns current DOM object counters.
 
@@ -166,9 +166,9 @@ def get_dom_counters() -> (
     return (int(json["documents"]), int(json["nodes"]), int(json["jsEventListeners"]))
 
 
-def get_dom_counters_for_leak_detection() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[DOMCounter]]
-):
+def get_dom_counters_for_leak_detection() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[DOMCounter]
+]:
     """
     Retruns DOM object counters after preparing renderer for leak detection.
 
@@ -192,9 +192,9 @@ def prepare_for_leak_detection() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, N
     json = yield cmd_dict
 
 
-def forcibly_purge_java_script_memory() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, None]
-):
+def forcibly_purge_java_script_memory() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, None
+]:
     """
     Simulate OomIntervention by purging V8 memory.
     """
@@ -270,9 +270,9 @@ def stop_sampling() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     json = yield cmd_dict
 
 
-def get_all_time_sampling_profile() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, SamplingProfile]
-):
+def get_all_time_sampling_profile() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, SamplingProfile
+]:
     """
     Retrieve native memory allocations profile
     collected since renderer process startup.
@@ -286,9 +286,9 @@ def get_all_time_sampling_profile() -> (
     return SamplingProfile.from_json(json["profile"])
 
 
-def get_browser_sampling_profile() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, SamplingProfile]
-):
+def get_browser_sampling_profile() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, SamplingProfile
+]:
     """
     Retrieve native memory allocations profile
     collected since browser process startup.
@@ -302,9 +302,9 @@ def get_browser_sampling_profile() -> (
     return SamplingProfile.from_json(json["profile"])
 
 
-def get_sampling_profile() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, SamplingProfile]
-):
+def get_sampling_profile() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, SamplingProfile
+]:
     """
     Retrieve native memory allocations profile collected since last
     ``startSampling`` call.

--- a/zendriver/cdp/profiler.py
+++ b/zendriver/cdp/profiler.py
@@ -257,9 +257,9 @@ def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     json = yield cmd_dict
 
 
-def get_best_effort_coverage() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[ScriptCoverage]]
-):
+def get_best_effort_coverage() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[ScriptCoverage]
+]:
     """
     Collect coverage data for the current isolate. The coverage data may be incomplete due to
     garbage collection.
@@ -351,11 +351,9 @@ def stop_precise_coverage() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     json = yield cmd_dict
 
 
-def take_precise_coverage() -> (
-    typing.Generator[
-        T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[ScriptCoverage], float]
-    ]
-):
+def take_precise_coverage() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[ScriptCoverage], float]
+]:
     """
     Collect coverage data for the current isolate, and resets execution counters. Precise code
     coverage needs to have started.

--- a/zendriver/cdp/runtime.py
+++ b/zendriver/cdp/runtime.py
@@ -1209,9 +1209,9 @@ def get_isolate_id() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
     return str(json["id"])
 
 
-def get_heap_usage() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[float, float]]
-):
+def get_heap_usage() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[float, float, float, float]
+]:
     """
     Returns the JavaScript heap usage.
     It is the total usage of the corresponding isolate not scoped to a particular Runtime.
@@ -1220,14 +1220,21 @@ def get_heap_usage() -> (
 
     :returns: A tuple with the following items:
 
-        0. **usedSize** - Used heap size in bytes.
-        1. **totalSize** - Allocated heap size in bytes.
+        0. **usedSize** - Used JavaScript heap size in bytes.
+        1. **totalSize** - Allocated JavaScript heap size in bytes.
+        2. **embedderHeapUsedSize** - Used size in bytes in the embedder's garbage-collected heap.
+        3. **backingStorageSize** - Size in bytes of backing storage for array buffers and external strings.
     """
     cmd_dict: T_JSON_DICT = {
         "method": "Runtime.getHeapUsage",
     }
     json = yield cmd_dict
-    return (float(json["usedSize"]), float(json["totalSize"]))
+    return (
+        float(json["usedSize"]),
+        float(json["totalSize"]),
+        float(json["embedderHeapUsedSize"]),
+        float(json["backingStorageSize"]),
+    )
 
 
 def get_properties(

--- a/zendriver/cdp/storage.py
+++ b/zendriver/cdp/storage.py
@@ -33,7 +33,6 @@ class StorageType(enum.Enum):
     Enum of possible storage types.
     """
 
-    APPCACHE = "appcache"
     COOKIES = "cookies"
     FILE_SYSTEMS = "file_systems"
     INDEXEDDB = "indexeddb"
@@ -183,38 +182,50 @@ class InterestGroupAuctionFetchType(enum.Enum):
         return cls(json)
 
 
-class SharedStorageAccessType(enum.Enum):
+class SharedStorageAccessScope(enum.Enum):
     """
-    Enum of shared storage access types.
+    Enum of shared storage access scopes.
     """
 
-    DOCUMENT_ADD_MODULE = "documentAddModule"
-    DOCUMENT_SELECT_URL = "documentSelectURL"
-    DOCUMENT_RUN = "documentRun"
-    DOCUMENT_SET = "documentSet"
-    DOCUMENT_APPEND = "documentAppend"
-    DOCUMENT_DELETE = "documentDelete"
-    DOCUMENT_CLEAR = "documentClear"
-    DOCUMENT_GET = "documentGet"
-    WORKLET_SET = "workletSet"
-    WORKLET_APPEND = "workletAppend"
-    WORKLET_DELETE = "workletDelete"
-    WORKLET_CLEAR = "workletClear"
-    WORKLET_GET = "workletGet"
-    WORKLET_KEYS = "workletKeys"
-    WORKLET_ENTRIES = "workletEntries"
-    WORKLET_LENGTH = "workletLength"
-    WORKLET_REMAINING_BUDGET = "workletRemainingBudget"
-    HEADER_SET = "headerSet"
-    HEADER_APPEND = "headerAppend"
-    HEADER_DELETE = "headerDelete"
-    HEADER_CLEAR = "headerClear"
+    WINDOW = "window"
+    SHARED_STORAGE_WORKLET = "sharedStorageWorklet"
+    PROTECTED_AUDIENCE_WORKLET = "protectedAudienceWorklet"
+    HEADER = "header"
 
     def to_json(self) -> str:
         return self.value
 
     @classmethod
-    def from_json(cls, json: str) -> SharedStorageAccessType:
+    def from_json(cls, json: str) -> SharedStorageAccessScope:
+        return cls(json)
+
+
+class SharedStorageAccessMethod(enum.Enum):
+    """
+    Enum of shared storage access methods.
+    """
+
+    ADD_MODULE = "addModule"
+    CREATE_WORKLET = "createWorklet"
+    SELECT_URL = "selectURL"
+    RUN = "run"
+    BATCH_UPDATE = "batchUpdate"
+    SET_ = "set"
+    APPEND = "append"
+    DELETE = "delete"
+    CLEAR = "clear"
+    GET = "get"
+    KEYS = "keys"
+    VALUES = "values"
+    ENTRIES = "entries"
+    LENGTH = "length"
+    REMAINING_BUDGET = "remainingBudget"
+
+    def to_json(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_json(cls, json: str) -> SharedStorageAccessMethod:
         return cls(json)
 
 
@@ -280,6 +291,52 @@ class SharedStorageMetadata:
 
 
 @dataclass
+class SharedStoragePrivateAggregationConfig:
+    """
+    Represents a dictionary object passed in as privateAggregationConfig to
+    run or selectURL.
+    """
+
+    #: Configures the maximum size allowed for filtering IDs.
+    filtering_id_max_bytes: int
+
+    #: The chosen aggregation service deployment.
+    aggregation_coordinator_origin: typing.Optional[str] = None
+
+    #: The context ID provided.
+    context_id: typing.Optional[str] = None
+
+    #: The limit on the number of contributions in the final report.
+    max_contributions: typing.Optional[int] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["filteringIdMaxBytes"] = self.filtering_id_max_bytes
+        if self.aggregation_coordinator_origin is not None:
+            json["aggregationCoordinatorOrigin"] = self.aggregation_coordinator_origin
+        if self.context_id is not None:
+            json["contextId"] = self.context_id
+        if self.max_contributions is not None:
+            json["maxContributions"] = self.max_contributions
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> SharedStoragePrivateAggregationConfig:
+        return cls(
+            filtering_id_max_bytes=int(json["filteringIdMaxBytes"]),
+            aggregation_coordinator_origin=str(json["aggregationCoordinatorOrigin"])
+            if json.get("aggregationCoordinatorOrigin", None) is not None
+            else None,
+            context_id=str(json["contextId"])
+            if json.get("contextId", None) is not None
+            else None,
+            max_contributions=int(json["maxContributions"])
+            if json.get("maxContributions", None) is not None
+            else None,
+        )
+
+
+@dataclass
 class SharedStorageReportingMetadata:
     """
     Pair of reporting metadata details for a candidate URL for ``selectURL()``.
@@ -340,69 +397,112 @@ class SharedStorageAccessParams:
     """
 
     #: Spec of the module script URL.
-    #: Present only for SharedStorageAccessType.documentAddModule.
+    #: Present only for SharedStorageAccessMethods: addModule and
+    #: createWorklet.
     script_source_url: typing.Optional[str] = None
 
+    #: String denoting "context-origin", "script-origin", or a custom
+    #: origin to be used as the worklet's data origin.
+    #: Present only for SharedStorageAccessMethod: createWorklet.
+    data_origin: typing.Optional[str] = None
+
     #: Name of the registered operation to be run.
-    #: Present only for SharedStorageAccessType.documentRun and
-    #: SharedStorageAccessType.documentSelectURL.
+    #: Present only for SharedStorageAccessMethods: run and selectURL.
     operation_name: typing.Optional[str] = None
 
+    #: Whether or not to keep the worket alive for future run or selectURL
+    #: calls.
+    #: Present only for SharedStorageAccessMethods: run and selectURL.
+    keep_alive: typing.Optional[bool] = None
+
+    #: Configures the private aggregation options.
+    #: Present only for SharedStorageAccessMethods: run and selectURL.
+    private_aggregation_config: typing.Optional[
+        SharedStoragePrivateAggregationConfig
+    ] = None
+
     #: The operation's serialized data in bytes (converted to a string).
-    #: Present only for SharedStorageAccessType.documentRun and
-    #: SharedStorageAccessType.documentSelectURL.
+    #: Present only for SharedStorageAccessMethods: run and selectURL.
+    #: TODO(crbug.com/401011862): Consider updating this parameter to binary.
     serialized_data: typing.Optional[str] = None
 
     #: Array of candidate URLs' specs, along with any associated metadata.
-    #: Present only for SharedStorageAccessType.documentSelectURL.
+    #: Present only for SharedStorageAccessMethod: selectURL.
     urls_with_metadata: typing.Optional[typing.List[SharedStorageUrlWithMetadata]] = (
         None
     )
 
+    #: Spec of the URN:UUID generated for a selectURL call.
+    #: Present only for SharedStorageAccessMethod: selectURL.
+    urn_uuid: typing.Optional[str] = None
+
     #: Key for a specific entry in an origin's shared storage.
-    #: Present only for SharedStorageAccessType.documentSet,
-    #: SharedStorageAccessType.documentAppend,
-    #: SharedStorageAccessType.documentDelete,
-    #: SharedStorageAccessType.workletSet,
-    #: SharedStorageAccessType.workletAppend,
-    #: SharedStorageAccessType.workletDelete,
-    #: SharedStorageAccessType.workletGet,
-    #: SharedStorageAccessType.headerSet,
-    #: SharedStorageAccessType.headerAppend, and
-    #: SharedStorageAccessType.headerDelete.
+    #: Present only for SharedStorageAccessMethods: set, append, delete, and
+    #: get.
     key: typing.Optional[str] = None
 
     #: Value for a specific entry in an origin's shared storage.
-    #: Present only for SharedStorageAccessType.documentSet,
-    #: SharedStorageAccessType.documentAppend,
-    #: SharedStorageAccessType.workletSet,
-    #: SharedStorageAccessType.workletAppend,
-    #: SharedStorageAccessType.headerSet, and
-    #: SharedStorageAccessType.headerAppend.
+    #: Present only for SharedStorageAccessMethods: set and append.
     value: typing.Optional[str] = None
 
     #: Whether or not to set an entry for a key if that key is already present.
-    #: Present only for SharedStorageAccessType.documentSet,
-    #: SharedStorageAccessType.workletSet, and
-    #: SharedStorageAccessType.headerSet.
+    #: Present only for SharedStorageAccessMethod: set.
     ignore_if_present: typing.Optional[bool] = None
+
+    #: If the method is called on a worklet, or as part of
+    #: a worklet script, it will have an ID for the associated worklet.
+    #: Present only for SharedStorageAccessMethods: addModule, createWorklet,
+    #: run, selectURL, and any other SharedStorageAccessMethod when the
+    #: SharedStorageAccessScope is worklet.
+    worklet_id: typing.Optional[str] = None
+
+    #: Name of the lock to be acquired, if present.
+    #: Optionally present only for SharedStorageAccessMethods: batchUpdate,
+    #: set, append, delete, and clear.
+    with_lock: typing.Optional[str] = None
+
+    #: If the method has been called as part of a batchUpdate, then this
+    #: number identifies the batch to which it belongs.
+    #: Optionally present only for SharedStorageAccessMethods:
+    #: batchUpdate (required), set, append, delete, and clear.
+    batch_update_id: typing.Optional[str] = None
+
+    #: Number of modifier methods sent in batch.
+    #: Present only for SharedStorageAccessMethod: batchUpdate.
+    batch_size: typing.Optional[int] = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = dict()
         if self.script_source_url is not None:
             json["scriptSourceUrl"] = self.script_source_url
+        if self.data_origin is not None:
+            json["dataOrigin"] = self.data_origin
         if self.operation_name is not None:
             json["operationName"] = self.operation_name
+        if self.keep_alive is not None:
+            json["keepAlive"] = self.keep_alive
+        if self.private_aggregation_config is not None:
+            json["privateAggregationConfig"] = self.private_aggregation_config.to_json()
         if self.serialized_data is not None:
             json["serializedData"] = self.serialized_data
         if self.urls_with_metadata is not None:
             json["urlsWithMetadata"] = [i.to_json() for i in self.urls_with_metadata]
+        if self.urn_uuid is not None:
+            json["urnUuid"] = self.urn_uuid
         if self.key is not None:
             json["key"] = self.key
         if self.value is not None:
             json["value"] = self.value
         if self.ignore_if_present is not None:
             json["ignoreIfPresent"] = self.ignore_if_present
+        if self.worklet_id is not None:
+            json["workletId"] = self.worklet_id
+        if self.with_lock is not None:
+            json["withLock"] = self.with_lock
+        if self.batch_update_id is not None:
+            json["batchUpdateId"] = self.batch_update_id
+        if self.batch_size is not None:
+            json["batchSize"] = self.batch_size
         return json
 
     @classmethod
@@ -411,8 +511,19 @@ class SharedStorageAccessParams:
             script_source_url=str(json["scriptSourceUrl"])
             if json.get("scriptSourceUrl", None) is not None
             else None,
+            data_origin=str(json["dataOrigin"])
+            if json.get("dataOrigin", None) is not None
+            else None,
             operation_name=str(json["operationName"])
             if json.get("operationName", None) is not None
+            else None,
+            keep_alive=bool(json["keepAlive"])
+            if json.get("keepAlive", None) is not None
+            else None,
+            private_aggregation_config=SharedStoragePrivateAggregationConfig.from_json(
+                json["privateAggregationConfig"]
+            )
+            if json.get("privateAggregationConfig", None) is not None
             else None,
             serialized_data=str(json["serializedData"])
             if json.get("serializedData", None) is not None
@@ -423,10 +534,25 @@ class SharedStorageAccessParams:
             ]
             if json.get("urlsWithMetadata", None) is not None
             else None,
+            urn_uuid=str(json["urnUuid"])
+            if json.get("urnUuid", None) is not None
+            else None,
             key=str(json["key"]) if json.get("key", None) is not None else None,
             value=str(json["value"]) if json.get("value", None) is not None else None,
             ignore_if_present=bool(json["ignoreIfPresent"])
             if json.get("ignoreIfPresent", None) is not None
+            else None,
+            worklet_id=str(json["workletId"])
+            if json.get("workletId", None) is not None
+            else None,
+            with_lock=str(json["withLock"])
+            if json.get("withLock", None) is not None
+            else None,
+            batch_update_id=str(json["batchUpdateId"])
+            if json.get("batchUpdateId", None) is not None
+            else None,
+            batch_size=int(json["batchSize"])
+            if json.get("batchSize", None) is not None
             else None,
         )
 
@@ -796,6 +922,26 @@ class AttributionScopesData:
 
 
 @dataclass
+class AttributionReportingNamedBudgetDef:
+    name: str
+
+    budget: int
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["name"] = self.name
+        json["budget"] = self.budget
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> AttributionReportingNamedBudgetDef:
+        return cls(
+            name=str(json["name"]),
+            budget=int(json["budget"]),
+        )
+
+
+@dataclass
 class AttributionReportingSourceRegistration:
     time: network.TimeSinceEpoch
 
@@ -833,6 +979,12 @@ class AttributionReportingSourceRegistration:
 
     max_event_level_reports: int
 
+    named_budgets: typing.List[AttributionReportingNamedBudgetDef]
+
+    debug_reporting: bool
+
+    event_level_epsilon: float
+
     debug_key: typing.Optional[UnsignedInt64AsBase10] = None
 
     scopes_data: typing.Optional[AttributionScopesData] = None
@@ -857,6 +1009,9 @@ class AttributionReportingSourceRegistration:
             self.aggregatable_debug_reporting_config.to_json()
         )
         json["maxEventLevelReports"] = self.max_event_level_reports
+        json["namedBudgets"] = [i.to_json() for i in self.named_budgets]
+        json["debugReporting"] = self.debug_reporting
+        json["eventLevelEpsilon"] = self.event_level_epsilon
         if self.debug_key is not None:
             json["debugKey"] = self.debug_key.to_json()
         if self.scopes_data is not None:
@@ -897,6 +1052,12 @@ class AttributionReportingSourceRegistration:
                 json["aggregatableDebugReportingConfig"]
             ),
             max_event_level_reports=int(json["maxEventLevelReports"]),
+            named_budgets=[
+                AttributionReportingNamedBudgetDef.from_json(i)
+                for i in json["namedBudgets"]
+            ],
+            debug_reporting=bool(json["debugReporting"]),
+            event_level_epsilon=float(json["eventLevelEpsilon"]),
             debug_key=UnsignedInt64AsBase10.from_json(json["debugKey"])
             if json.get("debugKey", None) is not None
             else None,
@@ -1078,6 +1239,27 @@ class AttributionReportingAggregatableDedupKey:
 
 
 @dataclass
+class AttributionReportingNamedBudgetCandidate:
+    filters: AttributionReportingFilterPair
+
+    name: typing.Optional[str] = None
+
+    def to_json(self) -> T_JSON_DICT:
+        json: T_JSON_DICT = dict()
+        json["filters"] = self.filters.to_json()
+        if self.name is not None:
+            json["name"] = self.name
+        return json
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> AttributionReportingNamedBudgetCandidate:
+        return cls(
+            filters=AttributionReportingFilterPair.from_json(json["filters"]),
+            name=str(json["name"]) if json.get("name", None) is not None else None,
+        )
+
+
+@dataclass
 class AttributionReportingTriggerRegistration:
     filters: AttributionReportingFilterPair
 
@@ -1100,6 +1282,8 @@ class AttributionReportingTriggerRegistration:
     )
 
     scopes: typing.List[str]
+
+    named_budgets: typing.List[AttributionReportingNamedBudgetCandidate]
 
     debug_key: typing.Optional[UnsignedInt64AsBase10] = None
 
@@ -1129,6 +1313,7 @@ class AttributionReportingTriggerRegistration:
             self.aggregatable_debug_reporting_config.to_json()
         )
         json["scopes"] = [i for i in self.scopes]
+        json["namedBudgets"] = [i.to_json() for i in self.named_budgets]
         if self.debug_key is not None:
             json["debugKey"] = self.debug_key.to_json()
         if self.aggregation_coordinator_origin is not None:
@@ -1168,6 +1353,10 @@ class AttributionReportingTriggerRegistration:
                 json["aggregatableDebugReportingConfig"]
             ),
             scopes=[str(i) for i in json["scopes"]],
+            named_budgets=[
+                AttributionReportingNamedBudgetCandidate.from_json(i)
+                for i in json["namedBudgets"]
+            ],
             debug_key=UnsignedInt64AsBase10.from_json(json["debugKey"])
             if json.get("debugKey", None) is not None
             else None,
@@ -1231,6 +1420,20 @@ class AttributionReportingAggregatableResult(enum.Enum):
 
     @classmethod
     def from_json(cls, json: str) -> AttributionReportingAggregatableResult:
+        return cls(json)
+
+
+class AttributionReportingReportResult(enum.Enum):
+    SENT = "sent"
+    PROHIBITED = "prohibited"
+    FAILED_TO_ASSEMBLE = "failedToAssemble"
+    EXPIRED = "expired"
+
+    def to_json(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_json(cls, json: str) -> AttributionReportingReportResult:
         return cls(json)
 
 
@@ -1572,9 +1775,9 @@ def untrack_indexed_db_for_storage_key(
     json = yield cmd_dict
 
 
-def get_trust_tokens() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[TrustTokens]]
-):
+def get_trust_tokens() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[TrustTokens]
+]:
     """
     Returns the number of stored Trust Tokens per issuer for the
     current browsing context.
@@ -1863,9 +2066,9 @@ def delete_storage_bucket(
     json = yield cmd_dict
 
 
-def run_bounce_tracking_mitigations() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]
-):
+def run_bounce_tracking_mitigations() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[str]
+]:
     """
     Deletes state for sites identified as potential bounce trackers, immediately.
 
@@ -1918,9 +2121,9 @@ def set_attribution_reporting_tracking(
     json = yield cmd_dict
 
 
-def send_pending_attribution_reports() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, int]
-):
+def send_pending_attribution_reports() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, int
+]:
     """
     Sends all pending Attribution Reports immediately, regardless of their
     scheduled report time.
@@ -1936,9 +2139,9 @@ def send_pending_attribution_reports() -> (
     return int(json["numSent"])
 
 
-def get_related_website_sets() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[RelatedWebsiteSet]]
-):
+def get_related_website_sets() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[RelatedWebsiteSet]
+]:
     """
     Returns the effective Related Website Sets in use by this profile for the browser
     session. The effective Related Website Sets will not change during a browser session.
@@ -1952,6 +2155,50 @@ def get_related_website_sets() -> (
     }
     json = yield cmd_dict
     return [RelatedWebsiteSet.from_json(i) for i in json["sets"]]
+
+
+def get_affected_urls_for_third_party_cookie_metadata(
+    first_party_url: str, third_party_urls: typing.List[str]
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+    """
+    Returns the list of URLs from a page and its embedded resources that match
+    existing grace period URL pattern rules.
+    https://developers.google.com/privacy-sandbox/cookies/temporary-exceptions/grace-period
+
+    **EXPERIMENTAL**
+
+    :param first_party_url: The URL of the page currently being visited.
+    :param third_party_urls: The list of embedded resource URLs from the page.
+    :returns: Array of matching URLs. If there is a primary pattern match for the first- party URL, only the first-party URL is returned in the array.
+    """
+    params: T_JSON_DICT = dict()
+    params["firstPartyUrl"] = first_party_url
+    params["thirdPartyUrls"] = [i for i in third_party_urls]
+    cmd_dict: T_JSON_DICT = {
+        "method": "Storage.getAffectedUrlsForThirdPartyCookieMetadata",
+        "params": params,
+    }
+    json = yield cmd_dict
+    return [str(i) for i in json["matchedUrls"]]
+
+
+def set_protected_audience_k_anonymity(
+    owner: str, name: str, hashes: typing.List[str]
+) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    """
+    :param owner:
+    :param name:
+    :param hashes:
+    """
+    params: T_JSON_DICT = dict()
+    params["owner"] = owner
+    params["name"] = name
+    params["hashes"] = [i for i in hashes]
+    cmd_dict: T_JSON_DICT = {
+        "method": "Storage.setProtectedAudienceKAnonymity",
+        "params": params,
+    }
+    json = yield cmd_dict
 
 
 @event_class("Storage.cacheStorageContentUpdated")
@@ -2163,12 +2410,16 @@ class SharedStorageAccessed:
 
     #: Time of the access.
     access_time: network.TimeSinceEpoch
+    #: Enum value indicating the access scope.
+    scope: SharedStorageAccessScope
     #: Enum value indicating the Shared Storage API method invoked.
-    type_: SharedStorageAccessType
+    method: SharedStorageAccessMethod
     #: DevTools Frame Token for the primary frame tree's root.
     main_frame_id: page.FrameId
-    #: Serialized origin for the context that invoked the Shared Storage API.
+    #: Serialization of the origin owning the Shared Storage data.
     owner_origin: str
+    #: Serialization of the site owning the Shared Storage data.
+    owner_site: str
     #: The sub-parameters wrapped by ``params`` are all optional and their
     #: presence/absence depends on ``type``.
     params: SharedStorageAccessParams
@@ -2177,9 +2428,11 @@ class SharedStorageAccessed:
     def from_json(cls, json: T_JSON_DICT) -> SharedStorageAccessed:
         return cls(
             access_time=network.TimeSinceEpoch.from_json(json["accessTime"]),
-            type_=SharedStorageAccessType.from_json(json["type"]),
+            scope=SharedStorageAccessScope.from_json(json["scope"]),
+            method=SharedStorageAccessMethod.from_json(json["method"]),
             main_frame_id=page.FrameId.from_json(json["mainFrameId"]),
             owner_origin=str(json["ownerOrigin"]),
+            owner_site=str(json["ownerSite"]),
             params=SharedStorageAccessParams.from_json(json["params"]),
         )
 
@@ -2253,4 +2506,39 @@ class AttributionReportingTriggerRegistered:
             aggregatable=AttributionReportingAggregatableResult.from_json(
                 json["aggregatable"]
             ),
+        )
+
+
+@event_class("Storage.attributionReportingReportSent")
+@dataclass
+class AttributionReportingReportSent:
+    """
+    **EXPERIMENTAL**
+
+
+    """
+
+    url: str
+    body: dict
+    result: AttributionReportingReportResult
+    #: If result is ``sent``, populated with net/HTTP status.
+    net_error: typing.Optional[int]
+    net_error_name: typing.Optional[str]
+    http_status_code: typing.Optional[int]
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT) -> AttributionReportingReportSent:
+        return cls(
+            url=str(json["url"]),
+            body=dict(json["body"]),
+            result=AttributionReportingReportResult.from_json(json["result"]),
+            net_error=int(json["netError"])
+            if json.get("netError", None) is not None
+            else None,
+            net_error_name=str(json["netErrorName"])
+            if json.get("netErrorName", None) is not None
+            else None,
+            http_status_code=int(json["httpStatusCode"])
+            if json.get("httpStatusCode", None) is not None
+            else None,
         )

--- a/zendriver/cdp/system_info.py
+++ b/zendriver/cdp/system_info.py
@@ -339,9 +339,9 @@ class ProcessInfo:
         )
 
 
-def get_info() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[GPUInfo, str, str, str]]
-):
+def get_info() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.Tuple[GPUInfo, str, str, str]
+]:
     """
     Returns information about the system.
 
@@ -383,9 +383,9 @@ def get_feature_state(
     return bool(json["featureEnabled"])
 
 
-def get_process_info() -> (
-    typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[ProcessInfo]]
-):
+def get_process_info() -> typing.Generator[
+    T_JSON_DICT, T_JSON_DICT, typing.List[ProcessInfo]
+]:
     """
     Returns information about all running processes.
 

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -476,7 +476,6 @@ class Browser:
             raise RuntimeError("Browser not yet started. use await browser.start()")
 
         permissions = list(cdp.browser.PermissionType)
-        permissions.remove(cdp.browser.PermissionType.FLASH)
         permissions.remove(cdp.browser.PermissionType.CAPTURED_SURFACE_CONTROL)
         await self.connection.send(cdp.browser.grant_permissions(permissions))
 


### PR DESCRIPTION
## Description

Updated CDP models to work with Chrome 136 (might relate to  #105).
This update solves an issue with the page domain where calls to Page.enable() would break, and page handlers would cause any subsequent update_target call to break.

Example code:
```python
import logging

import zendriver
from zendriver import cdp


async def main():
    browser = await zendriver.start(headless=False, sandbox=True)
    try:
        tab = await browser.get()

        # using this since cdp.page.enable() doesn't work in 0.7.0
        def page_enable():
            cmd = {
                "method": "Page.enable",
                "params": {
                    "enableFileChooserOpenedEvent": False
                }
            }

            yield cmd

        await tab.send(page_enable())

        await tab.send(cdp.page.set_lifecycle_events_enabled(True))

        async def load(event: cdp.page.LoadEventFired):
            logging.info(f"Page loaded {event.timestamp}")

        tab.add_handler(cdp.page.LoadEventFired, load)
        # here the code breaks since tab.wait calls Connection.update_target
        await tab.wait()
        await browser.get('https://www.google.com')
        await browser.wait(30)
    finally:
        await browser.stop()


if __name__ == '__main__':
    import asyncio

    logging.basicConfig(level=logging.INFO)

    asyncio.run(main())
```

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
