### PR TITLE
Fixing tests to make them run and pass on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixing tests so that they can run on Windows (and still run on Linux like before) @nathanfallet
+
 ### Added
 
 ### Changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,4 +123,7 @@ def handle_next_test(signum, frame):
     NEXT_TEST_EVENT.set()
 
 
-signal.signal(signal.SIGUSR1, handle_next_test)
+if hasattr(signal, 'SIGUSR1'):
+    signal.signal(signal.SIGUSR1, handle_next_test)
+else:
+    logger.warning("SIGUSR1 not available on this platform, handle_next_test will not be called.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,9 @@ def handle_next_test(signum, frame):
     NEXT_TEST_EVENT.set()
 
 
-if hasattr(signal, 'SIGUSR1'):
+if hasattr(signal, "SIGUSR1"):
     signal.signal(signal.SIGUSR1, handle_next_test)
 else:
-    logger.warning("SIGUSR1 not available on this platform, handle_next_test will not be called.")
+    logger.warning(
+        "SIGUSR1 not available on this platform, handle_next_test will not be called."
+    )

--- a/tests/sample_data/__init__.py
+++ b/tests/sample_data/__init__.py
@@ -2,5 +2,5 @@ from pathlib import Path
 
 
 def sample_file(name: str) -> str:
-    path = (Path(__file__).parent / name).absolute()
-    return f"file://{path}"
+    path = (Path(__file__).parent / name).resolve()
+    return path.as_uri()

--- a/zendriver/core/expect.py
+++ b/zendriver/core/expect.py
@@ -35,7 +35,7 @@ class BaseRequestExpectation:
         :param event: The request event.
         :type event: cdp.network.RequestWillBeSent
         """
-        if re.fullmatch(self.url_pattern, event.request.url):
+        if re.fullmatch(re.escape(self.url_pattern), event.request.url):
             self._remove_request_handler()
             self.request_id = event.request_id
             self.request_future.set_result(event)

--- a/zendriver/core/expect.py
+++ b/zendriver/core/expect.py
@@ -35,7 +35,7 @@ class BaseRequestExpectation:
         :param event: The request event.
         :type event: cdp.network.RequestWillBeSent
         """
-        if re.fullmatch(re.escape(self.url_pattern), event.request.url):
+        if re.fullmatch(self.url_pattern, event.request.url):
             self._remove_request_handler()
             self.request_id = event.request_id
             self.request_future.set_result(event)


### PR DESCRIPTION
## Description

This is a pre-requirement to work on #113. Since this issue is mostly about Windows, I needed to ensure all tests were passing on Windows before starting to make changes.

Here are explanation about what changed and why:
- `signal.SIGUSR1` is not available on Windows, so I had to check this; otherwise, tests wouldn't start at all.
- `sample_file()` was returning a path with `\` on Windows, while cdp still returns URIs with `/`. So the function is now using URIs to match cdp formatting.

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
