### PR TITLE
Adding `config.disable_asyncio_subprocess` to allow to use `WindowsSelectorEventLoopPolicy` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixing tests so that they can run on Windows (and still run on Linux like before) @nathanfallet
+- Adding `config.disable_asyncio_subprocess` option to disable asyncio subprocesses on Windows @nathanfallet
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixing tests so that they can run on Windows (and still run on Linux like before) @nathanfallet
-- Adding `config.disable_asyncio_subprocess` option to disable asyncio subprocesses on Windows @nathanfallet
+- Disable asyncio subprocesses for better compatibility on Windows @nathanfallet
 
 ### Added
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -93,7 +93,21 @@ config.user_data_dir="/path/to/existing/profile",  # by specifying it, it won't 
 config.browser_executable_path="/path/to/some/other/browser",
 config.browser_args=['--some-browser-arg=true', '--some-other-option'],
 config.lang="en-US"   # this could set iso-language-code in navigator, not recommended to change
-)
+```
+
+On Windows, we recommend using `WindowsSelectorEventLoopPolicy` for better compatibility with asyncio:
+
+```python
+import asyncio
+import sys
+import zendriver as zd
+
+config = zd.Config()
+# ...
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    config.disable_asyncio_subprocess = True # required since WindowsSelectorEventLoopPolicy does not support asyncio subprocesses
 ```
 
 A more concrete example, which can be found in the ./example/ folder,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,14 +100,9 @@ On Windows, we recommend using `WindowsSelectorEventLoopPolicy` for better compa
 ```python
 import asyncio
 import sys
-import zendriver as zd
-
-config = zd.Config()
-# ...
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    config.disable_asyncio_subprocess = True # required since WindowsSelectorEventLoopPolicy does not support asyncio subprocesses
 ```
 
 A more concrete example, which can be found in the ./example/ folder,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+import asyncio
 import logging
 import os
 import signal
+import sys
 from contextlib import AbstractAsyncContextManager
 from enum import Enum
 from threading import Event
@@ -88,6 +90,9 @@ class CreateBrowser(AbstractAsyncContextManager):
 def create_browser(
     disable_asyncio_subprocess: bool,
 ) -> type[CreateBrowser] | functools.partial[CreateBrowser]:
+    if disable_asyncio_subprocess and sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore
+
     return functools.partial(
         CreateBrowser, disable_asyncio_subprocess=disable_asyncio_subprocess
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from contextlib import AbstractAsyncContextManager
 from enum import Enum
 from threading import Event
 from typing import AsyncGenerator
-import functools
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,6 @@ class CreateBrowser(AbstractAsyncContextManager):
         browser_args: list[str] | None = None,
         browser_connection_max_tries: int = 15,
         browser_connection_timeout: float = 3.0,
-        disable_asyncio_subprocess: bool = False,
     ):
         args = []
         if not headless and TestConfig.USE_WAYLAND:
@@ -67,7 +66,6 @@ class CreateBrowser(AbstractAsyncContextManager):
             browser_args=args,
             browser_connection_max_tries=browser_connection_max_tries,
             browser_connection_timeout=browser_connection_timeout,
-            disable_asyncio_subprocess=disable_asyncio_subprocess,
         )
 
         self.browser: zd.Browser | None = None
@@ -87,27 +85,16 @@ class CreateBrowser(AbstractAsyncContextManager):
 
 
 @pytest.fixture
-def create_browser(
-    disable_asyncio_subprocess: bool,
-) -> type[CreateBrowser] | functools.partial[CreateBrowser]:
-    if disable_asyncio_subprocess and sys.platform == "win32":
+def create_browser() -> type[CreateBrowser]:
+    if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore
 
-    return functools.partial(
-        CreateBrowser, disable_asyncio_subprocess=disable_asyncio_subprocess
-    )
+    return CreateBrowser
 
 
 @pytest.fixture(params=TestConfig.BROWSER_MODE.fixture_params)
 def headless(request: pytest.FixtureRequest) -> bool:
     return request.param["headless"]
-
-
-@pytest.fixture(
-    params=[{"disable_asyncio_subprocess": False}, {"disable_asyncio_subprocess": True}]
-)
-def disable_asyncio_subprocess(request: pytest.FixtureRequest) -> bool:
-    return request.param["disable_asyncio_subprocess"]
 
 
 @pytest.fixture

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -10,6 +10,7 @@ import pathlib
 import pickle
 import re
 import shutil
+import subprocess
 import urllib.parse
 import urllib.request
 import warnings
@@ -54,7 +55,7 @@ class Browser:
 
     """
 
-    _process: asyncio.subprocess.Process | None
+    _process: asyncio.subprocess.Process | subprocess.Popen | None
     _process_pid: int | None
     _http: HTTPApi | None = None
     _cookies: CookieJar | None = None
@@ -354,17 +355,8 @@ class Browser:
             "starting\n\texecutable :%s\n\narguments:\n%s", exe, "\n\t".join(params)
         )
         if not connect_existing:
-            self._process: asyncio.subprocess.Process = (
-                await asyncio.create_subprocess_exec(
-                    # self.config.browser_executable_path,
-                    # *cmdparams,
-                    exe,
-                    *params,
-                    stdin=asyncio.subprocess.PIPE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    close_fds=is_posix,
-                )
+            self._process = await util._start_process(
+                exe, params, is_posix, self.config.disable_asyncio_subprocess
             )
             self._process_pid = self._process.pid
 
@@ -619,7 +611,10 @@ class Browser:
                     self._process.kill()
                     logger.debug("killed browser process")
 
-                await self._process.wait()
+                if isinstance(self._process, asyncio.subprocess.Process):
+                    await self._process.wait()
+                else:
+                    self._process.wait()
 
             except ProcessLookupError:
                 # ignore this well known race condition because it only means that

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -55,7 +55,7 @@ class Browser:
 
     """
 
-    _process: asyncio.subprocess.Process | subprocess.Popen | None
+    _process: subprocess.Popen | None
     _process_pid: int | None
     _http: HTTPApi | None = None
     _cookies: CookieJar | None = None
@@ -355,9 +355,7 @@ class Browser:
             "starting\n\texecutable :%s\n\narguments:\n%s", exe, "\n\t".join(params)
         )
         if not connect_existing:
-            self._process = await util._start_process(
-                exe, params, is_posix, self.config.disable_asyncio_subprocess
-            )
+            self._process = util._start_process(exe, params, is_posix)
             self._process_pid = self._process.pid
 
         self._http = HTTPApi((self.config.host, self.config.port))
@@ -611,10 +609,7 @@ class Browser:
                     self._process.kill()
                     logger.debug("killed browser process")
 
-                if isinstance(self._process, asyncio.subprocess.Process):
-                    await self._process.wait()
-                else:
-                    self._process.wait()
+                await asyncio.to_thread(self._process.wait)
 
             except ProcessLookupError:
                 # ignore this well known race condition because it only means that

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -42,6 +42,7 @@ class Config:
         expert: bool | None = AUTO,
         browser_connection_timeout: float = 0.25,
         browser_connection_max_tries: int = 10,
+        disable_asyncio_subprocess: bool = False,
         **kwargs: Any,
     ):
         """
@@ -65,6 +66,8 @@ class Config:
         :param expert: when set to True, enabled "expert" mode.
                This conveys, the inclusion of parameters: --disable-web-security ----disable-site-isolation-trials,
                as well as some scripts and patching useful for debugging (for example, ensuring shadow-root is always in "open" mode)
+        :param disable_asyncio_subprocess: when set to True, disables the asyncio subprocess and use the standard subprocess module instead.
+               On Windows, this might be preferable to use WindowsSelectorEventLoopPolicy, which is not compatible with asyncio subprocesses.
 
         :param kwargs:
 
@@ -111,6 +114,7 @@ class Config:
 
         self.browser_connection_timeout = browser_connection_timeout
         self.browser_connection_max_tries = browser_connection_max_tries
+        self.disable_asyncio_subprocess = disable_asyncio_subprocess
 
         # other keyword args will be accessible by attribute
         self.__dict__.update(kwargs)

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -42,7 +42,6 @@ class Config:
         expert: bool | None = AUTO,
         browser_connection_timeout: float = 0.25,
         browser_connection_max_tries: int = 10,
-        disable_asyncio_subprocess: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -66,9 +65,6 @@ class Config:
         :param expert: when set to True, enabled "expert" mode.
                This conveys, the inclusion of parameters: --disable-web-security ----disable-site-isolation-trials,
                as well as some scripts and patching useful for debugging (for example, ensuring shadow-root is always in "open" mode)
-        :param disable_asyncio_subprocess: when set to True, disables the asyncio subprocess and use the standard subprocess module instead.
-               On Windows, this might be preferable to use WindowsSelectorEventLoopPolicy, which is not compatible with asyncio subprocesses.
-               By default, this is set to True on Windows and False on other platforms.
 
         :param kwargs:
 
@@ -115,11 +111,6 @@ class Config:
 
         self.browser_connection_timeout = browser_connection_timeout
         self.browser_connection_max_tries = browser_connection_max_tries
-
-        if disable_asyncio_subprocess is None:
-            # default to True on Windows, False on other platforms
-            disable_asyncio_subprocess = not is_posix
-        self.disable_asyncio_subprocess = disable_asyncio_subprocess
 
         # other keyword args will be accessible by attribute
         self.__dict__.update(kwargs)

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -42,7 +42,7 @@ class Config:
         expert: bool | None = AUTO,
         browser_connection_timeout: float = 0.25,
         browser_connection_max_tries: int = 10,
-        disable_asyncio_subprocess: bool = False,
+        disable_asyncio_subprocess: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -68,6 +68,7 @@ class Config:
                as well as some scripts and patching useful for debugging (for example, ensuring shadow-root is always in "open" mode)
         :param disable_asyncio_subprocess: when set to True, disables the asyncio subprocess and use the standard subprocess module instead.
                On Windows, this might be preferable to use WindowsSelectorEventLoopPolicy, which is not compatible with asyncio subprocesses.
+               By default, this is set to True on Windows and False on other platforms.
 
         :param kwargs:
 
@@ -114,6 +115,10 @@ class Config:
 
         self.browser_connection_timeout = browser_connection_timeout
         self.browser_connection_max_tries = browser_connection_max_tries
+
+        if disable_asyncio_subprocess is None:
+            # default to True on Windows, False on other platforms
+            disable_asyncio_subprocess = not is_posix
         self.disable_asyncio_subprocess = disable_asyncio_subprocess
 
         # other keyword args will be accessible by attribute

--- a/zendriver/core/util.py
+++ b/zendriver/core/util.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import subprocess
 import types
 import typing
+from pathlib import Path
 from typing import Any, Callable, List, Optional, Set, Union
 
 from deprecated import deprecated
@@ -328,19 +330,62 @@ def cdp_get_module(domain: Union[str, types.ModuleType]):
     return domain_mod
 
 
+async def _start_process(
+    exe: str | Path, params: List[str], is_posix: bool, disable_asyncio_subprocess: bool
+) -> asyncio.subprocess.Process | subprocess.Popen:
+    """
+    Start a subprocess with the given executable and parameters.
+    If `disable_asyncio_subprocess` is True, it uses `subprocess.Popen` directly.
+    If `disable_asyncio_subprocess` is False, it uses `asyncio.create_subprocess_exec`.
+
+    :param exe: The executable to run.
+    :param params: List of parameters to pass to the executable.
+    :param is_posix: Boolean indicating if the system is POSIX compliant.
+    :param disable_asyncio_subprocess: If True, use `subprocess.Popen` instead of `asyncio.create_subprocess_exec`.
+
+    :return: An instance of `asyncio.subprocess.Process` or `subprocess.Popen`.
+    """
+    if disable_asyncio_subprocess:
+        # On Windows, we might prefer to use subprocess.Popen directly, to solve async issues
+        # using WindowsSelectorEventLoopPolicy, since it does not support asyncio.subprocess
+        return subprocess.Popen(
+            [str(exe)] + params,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            close_fds=is_posix,
+        )
+
+    return await asyncio.create_subprocess_exec(
+        exe,
+        *params,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        close_fds=is_posix,
+    )
+
+
 async def _read_process_stderr(
-    process: asyncio.subprocess.Process, n: int = 2**16
+    process: asyncio.subprocess.Process | subprocess.Popen, n: int = 2**16
 ) -> str:
     """
     Read the given number of bytes from the stderr of the given process.
 
     Read bytes are automatically decoded to utf-8.
     """
-    if process.stderr is None:
-        raise ValueError("Process has no stderr")
+
+    async def read_stderr() -> bytes:
+        if process.stderr is None:
+            raise ValueError("Process has no stderr")
+
+        if isinstance(process, asyncio.subprocess.Process):
+            return await process.stderr.read(n)
+        else:
+            return await asyncio.to_thread(process.stderr.read, n)
 
     try:
-        return (await asyncio.wait_for(process.stderr.read(n), 0.25)).decode("utf-8")
+        return (await asyncio.wait_for(read_stderr(), 0.25)).decode("utf-8")
     except asyncio.TimeoutError:
         logger.debug("Timeout reading process stderr")
         return ""

--- a/zendriver/core/util.py
+++ b/zendriver/core/util.py
@@ -351,9 +351,7 @@ def _start_process(
     )
 
 
-async def _read_process_stderr(
-    process: subprocess.Popen, n: int = 2**16
-) -> str:
+async def _read_process_stderr(process: subprocess.Popen, n: int = 2**16) -> str:
     """
     Read the given number of bytes from the stderr of the given process.
 


### PR DESCRIPTION
## Description

Fixes #113 

On Windows, the default `WindowsProactorEventLoopPolicy` causes issues with `asyncio` (known as event loop lags).
Using `WindowsSelectorEventLoopPolicy` solves the problem. But for this, we are required to use python subprocesses instead of asyncio's. That's why we added `config.disable_asyncio_subprocess` to allow the switch.

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
