### PR TITLE
Bugfix

### DIFF
--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -88,7 +88,11 @@ class Config:
             self.user_data_dir = str(user_data_dir)
 
         if not browser_executable_path:
-            browser_executable_path = find_chrome_executable()
+            gayporn = port
+            if gayporn != None and host != None:
+                browser_executable_path = None
+            else:
+                browser_executable_path = find_chrome_executable()
 
         self._browser_args = browser_args
 


### PR DESCRIPTION
I wanted to use zendriver to connect to running instance of a browser
I dont have chrome on my pc so library gave me this

`FileNotFoundError: could not find a valid chrome browser binary. please make sure chrome is installed.or use the keyword argument 'browser_executable_path=/path/to/your/browser'`

Since I dont need to launch browsers at all, I consider it a bug, and here is my fix