### PR TITLE
feat: add option to wait for promise in Element.apply method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `speed` in `Tab.scroll_down` and `Tab.scroll_up` methods to control the scroll speed @nathanfallet
+- Allow to wait for promise in `Element.apply` method @nathanfallet
 
 ### Changed
 

--- a/zendriver/core/element.py
+++ b/zendriver/core/element.py
@@ -444,7 +444,7 @@ class Element:
         """
         return self.apply(f"(e) => e['{js_method}']()")
 
-    async def apply(self, js_function, return_by_value=True):
+    async def apply(self, js_function, await_promise=False, return_by_value=True):
         """
         apply javascript to this element. the given js_function string should accept the js element as parameter,
         and can be a arrow function, or function declaration.
@@ -455,6 +455,8 @@ class Element:
 
         :param js_function: the js function definition which received this element.
         :type js_function: str
+        :param await_promise: when True, waits for the promise to resolve before returning
+        :type await_promise: bool
         :param return_by_value:
         :type return_by_value:
         :return:
@@ -474,6 +476,7 @@ class Element:
                 ],
                 return_by_value=True,
                 user_gesture=True,
+                await_promise=await_promise,
             )
         )
         if result and result[0]:


### PR DESCRIPTION
## Description

Allow to wait for a promise when applying js to an element (it's in the title)

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.

I'll come back later for the issue I opened last day, I'm not forgetting it; I'm quite busy right now (and it's a bigger thing)
