### PR TITLE
feat: add clear_input_by_deleting method to simulate delete key presses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `speed` in `Tab.scroll_down` and `Tab.scroll_up` methods to control the scroll speed @nathanfallet
 - Allow to wait for promise in `Element.apply` method @nathanfallet
+- Added `Element.clear_input_by_deleting` to handle inputs with custom delete behavior @nathanfallet
 
 ### Changed
 

--- a/zendriver/core/element.py
+++ b/zendriver/core/element.py
@@ -694,6 +694,39 @@ class Element:
         """clears an input field"""
         return await self.apply('function (element) { element.value = "" } ')
 
+    async def clear_input_by_deleting(self):
+        """
+        clears the input of the element by simulating a series of delete key presses.
+
+        this method applies a JavaScript function that simulates pressing the delete key
+        repeatedly until the input is empty. it is useful for clearing input fields or text areas
+        when :func:`clear_input` does not work (for example, when custom input handling is implemented on the page).
+        """
+        return await self.apply(
+            """
+                async function clearByDeleting(n, d = 50) {
+                    n.focus();
+                    n.setSelectionRange(0, 0);
+                    while (n.value.length > 0) {
+                        n.dispatchEvent(
+                            new KeyboardEvent("keydown", {
+                                key: "Delete",
+                                code: "Delete",
+                                keyCode: 46,
+                                which: 46,
+                                bubbles: !0,
+                                cancelable: !0,
+                            })
+                        );
+                        n.value = n.value.slice(1);
+                        await new Promise((r) => setTimeout(r, d));
+                    }
+                    n.dispatchEvent(new Event("input", { bubbles: !0 }));
+                }
+            """,
+            await_promise=True,
+        )
+
     async def send_keys(self, text: str, special_characters: bool = False):
         """
         send text to an input field, or any other html element.


### PR DESCRIPTION
## Description

In some cases (I can't mention the website where we got this issue), the input field has a custom behaviour (for example when the website uses React and has a custom onBlur method), so the classic `clear_input` does not work.

We found a workaround simulating backspace key presses, that we implemented here: https://github.com/guimauvedigital/kdriver/pull/5

That's also why I needed #135 before.

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
