### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor element waiting loops in `find_*` and `select*` methods. @H1steria
 - Improve `query_selector` error handling to consistently return `None` when a node is not found. @H1steria
+- add user agent option and auto-generate for headless to bypass cloudflare javascript challenge. @H1steria
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.10.0] - 2025-07-04
+
+### Fixed
+
+- Refactor element waiting loops in `find_*` and `select*` methods. @H1steria
+- Improve `query_selector` error handling to consistently return `None` when a node is not found. @H1steria
+
+### Added
+
+- Added `mouse_move` and `mouse_click` methods from nodriver. @H1steria
+
 ## [0.9.0] - 2025-07-01
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,9 +112,9 @@ If this is your first time making a contribution on GitHub, please review the [o
 When submitting a pull request, please stick to the following guidelines:
 
 1. Describe your change in the body of your pull request, ideally linking to an existing GitHub issue for the bug/enhancement you are addressing. Note, if you use the word "closes", "fixes", or "resolves" before linking your issue, the issue will be automatically closed when the pull request is merged (see [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)).
-2. Ensure that any newly added/modified code is autoformatted and free of lint errors. To verify this, use the [`scripts/lint.sh`](blob/main/scripts/lint.sh) script to run `ruff` and `mypy` against your code.
+2. Ensure that any newly added/modified code is autoformatted and free of lint errors. To verify this, use the [`scripts/lint.sh`](scripts/lint.sh) script to run `ruff` and `mypy` against your code.
    - Note, at the time of writing there are still many, many `mypy` errors left over from the `nodriver` fork. Please disregard these and consider only errors related to the code you have changed.
-3. Get credit for your work! Add your changes to [`CHANGELOG.md`](blob/main/CHANGELOG.md) under the `[UNRELEASED]` section and optionally include your GitHub handle at the end of the line.
+3. Get credit for your work! Add your changes to [`CHANGELOG.md`](CHANGELOG.md) under the `[UNRELEASED]` section and optionally include your GitHub handle at the end of the line.
 
 ### Improving The Documentation
 

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -70,6 +70,7 @@ class Browser:
         *,
         user_data_dir: PathLike | None = None,
         headless: bool = False,
+        user_agent: str | None = None,
         browser_executable_path: PathLike | None = None,
         browser_args: List[str] | None = None,
         sandbox: bool = True,
@@ -81,9 +82,22 @@ class Browser:
         entry point for creating an instance
         """
         if not config:
+            if headless and not user_agent:
+                import latest_user_agents
+                import random
+
+                # Get a random up-to-date Chrome user agent string.
+                chrome_user_agents = [
+                    ua
+                    for ua in latest_user_agents.get_latest_user_agents()
+                    if "Chrome" in ua and "Edg" not in ua
+                ]
+                user_agent = random.choice(chrome_user_agents)
+
             config = Config(
                 user_data_dir=user_data_dir,
                 headless=headless,
+                user_agent=user_agent,
                 browser_executable_path=browser_executable_path,
                 browser_args=browser_args or [],
                 sandbox=sandbox,

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -82,18 +82,6 @@ class Browser:
         entry point for creating an instance
         """
         if not config:
-            if headless and not user_agent:
-                import latest_user_agents
-                import random
-
-                # Get a random up-to-date Chrome user agent string.
-                chrome_user_agents = [
-                    ua
-                    for ua in latest_user_agents.get_latest_user_agents()
-                    if "Chrome" in ua and "Edg" not in ua
-                ]
-                user_agent = random.choice(chrome_user_agents)
-
             config = Config(
                 user_data_dir=user_data_dir,
                 headless=headless,

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -33,6 +33,7 @@ class Config:
         self,
         user_data_dir: Optional[PathLike] = AUTO,
         headless: Optional[bool] = False,
+        user_agent: Optional[str] = None,
         browser_executable_path: Optional[PathLike] = AUTO,
         browser_args: Optional[List[str]] = AUTO,
         sandbox: Optional[bool] = True,
@@ -62,6 +63,7 @@ class Config:
         :param sandbox: disables sandbox
         :param autodiscover_targets: use autodiscovery of targets
         :param lang: language string to use other than the default "en-US,en;q=0.9"
+        :param user_agent: custom user-agent string
         :param expert: when set to True, enabled "expert" mode.
                This conveys, the inclusion of parameters: --disable-web-security ----disable-site-isolation-trials,
                as well as some scripts and patching useful for debugging (for example, ensuring shadow-root is always in "open" mode)
@@ -74,6 +76,7 @@ class Config:
         :type browser_args: list[str]
         :type sandbox: bool
         :type lang: str
+        :type user_agent: str
         :type kwargs: dict
         """
 
@@ -91,9 +94,9 @@ class Config:
             browser_executable_path = find_chrome_executable()
 
         self._browser_args = browser_args
-
         self.browser_executable_path = browser_executable_path
         self.headless = headless
+        self.user_agent = user_agent
         self.sandbox = sandbox
         self.host = host
         self.port = port
@@ -210,6 +213,8 @@ class Config:
             args.extend([arg for arg in self._browser_args if arg not in args])
         if self.headless:
             args.append("--headless=new")
+        if self.user_agent:
+            args.append(f"--user-agent={self.user_agent}")
         if not self.sandbox:
             args.append("--no-sandbox")
         if self.host:


### PR DESCRIPTION
## Description

<!-- Please describe your change below this line -->
`close #99`
Added `Tab.mouse_move()` and `Tab.mouse_click()` from nodriver.

`fix #76`
On pages with a rapidly changing DOM, the root node could become stale between getting the document reference (cdp.dom.get_document) and running the query (cdp.dom.query_selector). This used to cause a ProtocolException ("could not find node with given id"), stopping the script.
Now, instead of crashing, the method treats this as a failed selector match for that attempt and safely returns None. This lets higher-level methods (e.g., select) continue their polling loop and retry on the new DOM.

Refactor `find`, `select`, `find_all`, `select_all`:
While loops have been restructured into a cleaner while True pattern.
TimeoutError messages were improved to be more specific.

`fix`
Relative paths from `lint.sh` and `CHANGELOG.md` in contributing guide has updated.

`#112`
added a new 'user_agent' parameter to the Browser and Config classes,
allowing users to specify a custom user-agent string, this allow bypass the javascript challenge.

When running in headless mode without a specified user agent, the system
will now automatically select a random, up-to-date Chrome user agent. The provided or generated user agent is passed
to the browser via the '--user-agent' argument. adapted from [CF-Clearance-Scraper](https://github.com/Xewdy444/CF-Clearance-Scraper).

`tab.set_user_agent()` or `cdp.network.set_user_agent_override()` is insufficient.

test:
````
import asyncio
import zendriver

async def main():
    browser = None
    try:
        url = "https://ww3.animeonline.ninja/"
        # url = "https://httpbin.io/user-agent"
        # user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
        
        browser1 = await zendriver.Browser.create(headless=True, user_agent="test")
        browser2 = await zendriver.Browser.create(headless=True)

        tab1 = await browser1.get()
        tab2 = await browser2.get()

        await asyncio.sleep(1)
        
        await tab1.get(url)
        await tab2.get(url)

        await asyncio.sleep(10)

        await tab1.save_screenshot("fail.png")
        await tab2.save_screenshot("new_method.png")
        print("screenshots saved")

    except Exception as e:
        print(f"Ocurrió un error: {e}")
    finally:
        if browser1:
            await browser1.stop()
        if browser2:
            await browser2.stop()

if __name__ == "__main__":
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        print("\nProceso interrumpido por el usuario.")
````

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/stephanlensky/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/stephanlensky/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
