### PR TITLE
fix(core): resolve NameError for Element in Tab methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `NameError` in `Tab.query_selector` and `Tab.query_selector_all` due to type-checking import of `Element`. @Avejack
+
 ### Added
 
 ### Changed

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -463,7 +463,7 @@ class Tab(Connection):
                         return []
                     # if supplied node is not found, the dom has changed since acquiring the element
                     # therefore we need to update our passed node and try again
-                    if isinstance(_node, Element):
+                    if isinstance(_node, element.Element):
                         await _node.update()
                     # make sure this isn't turned into infinite loop
                     setattr(_node, "__last", True)
@@ -521,7 +521,7 @@ class Tab(Connection):
                         return None
                     # if supplied node is not found, the dom has changed since acquiring the element
                     # therefore we need to update our passed node and try again
-                    if isinstance(_node, Element):
+                    if isinstance(_node, element.Element):
                         await _node.update()
                     # make sure this isn't turned into infinite loop
                     setattr(_node, "__last", True)


### PR DESCRIPTION
## Description

This PR fixes a `NameError` in `Tab.query_selector` and `Tab.query_selector_all` that occurs because the `Element` class is not available at runtime for `isinstance` checks.

The `Element` type hint is correctly placed within a `TYPE_CHECKING` block to avoid circular imports. This change updates the runtime `isinstance` check to use the module-qualified `element.Element`, resolving the error while respecting the existing import architecture.

Fixes #230 

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
