### PR TITLE
fix(core): retry query_selector on stale document ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix race condition in `Tab.query_selector` and `Tab.query_selector_all` on stale document. @Avejack
+
 ### Added
 
 ### Changed


### PR DESCRIPTION
## Description

This PR fixes a race condition where `Tab.query_selector` and `Tab.query_selector_all` would fail if the document node ID became invalid immediately after being fetched.

- In `query_selector_all`, the method now catches the specific `ProtocolException` when the document is stale, re-fetches the document, and retries.
- In `query_selector`, the method no longer returns `None` (masking the error) when the document is stale; instead, it re-fetches and retries.

Both implementations piggyback on the existing retry logic (passing the new doc as `_node`). We explicitly set `__last=True` on the new document node to ensure we retry exactly once and prevent infinite recursion or double-retries.

## Related Issue

Closes #234 

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
