### PR TITLE
Fix/chrome146 sameparty cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix crash in `browser.cookies.get_all()` on Chrome 146 when the `sameParty` field is missing in the cookie JSON returned by CDP.
+
 - Fix `clear_input()` and `clear_input_by_deleting()` silently failing on React controlled inputs due to `_valueTracker` mechanism; also fix infinite loop in `clear_input_by_deleting()` on some VM environments caused by `VK_DELETE` being treated as backward-delete. @nathanfallet
 
 ### Added

--- a/zendriver/cdp/network.py
+++ b/zendriver/cdp/network.py
@@ -1527,7 +1527,9 @@ class Cookie:
             secure=bool(json["secure"]),
             session=bool(json["session"]),
             priority=CookiePriority.from_json(json["priority"]),
-            same_party=bool(json["sameParty"]),
+            same_party=bool(json["sameParty"])
+            if json.get("sameParty", None) is not None
+            else False,
             source_scheme=CookieSourceScheme.from_json(json["sourceScheme"]),
             source_port=int(json["sourcePort"]),
             expires=float(json["expires"])


### PR DESCRIPTION
## Description

Fixes #244

Chrome version 146 introduced a change in the cookie structure returned by the Chrome DevTools Protocol where the sameParty field can be optional.

Because of this, the method browser.cookies.get_all() currently crashes when parsing cookies if the sameParty field is not present in the JSON response. This leads to a failure during cookie initialization in Cookie.from_json.

User @creaman reported this issue and proposed a solution in:
https://github.com/cdpdriver/zendriver/issues/244

Tested with Chrome 146 where browser.cookies.get_all() previously crashed.

## Pre-merge Checklist

- [X] I have described my change in the section above.
- [X] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [X] I have ran `uv run pytest` and ensured all tests pass.
- [X] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
