### PR TITLE
fix(network): KeyError on Chrome 146 due to CDP privateNetworkRequestPolicy rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `KeyError` on Chrome 146+ due to CDP renaming `privateNetworkRequestPolicy` to `localNetworkAccessRequestPolicy` in `Network.requestWillBeSentExtraInfo`
+
 ### Added
 
 ### Changed

--- a/zendriver/cdp/network.py
+++ b/zendriver/cdp/network.py
@@ -2481,13 +2481,18 @@ class ClientSecurityState:
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ClientSecurityState:
+        policy_key = (
+            "privateNetworkRequestPolicy"
+            if "privateNetworkRequestPolicy" in json
+            else "localNetworkAccessRequestPolicy"
+        )
         return cls(
             initiator_is_secure_context=bool(json["initiatorIsSecureContext"]),
             initiator_ip_address_space=IPAddressSpace.from_json(
                 json["initiatorIPAddressSpace"]
             ),
             private_network_request_policy=PrivateNetworkRequestPolicy.from_json(
-                json["privateNetworkRequestPolicy"]
+                json[policy_key]
             ),
         )
 


### PR DESCRIPTION
## Description

Chrome 146 renamed the CDP field `privateNetworkRequestPolicy` to `localNetworkAccessRequestPolicy` in the `Network.requestWillBeSentExtraInfo` event's `clientSecurityState` object. This causes zendriver to throw a `KeyError` on nearly every network request, flooding logs with tracebacks.

The fix updates `ClientSecurityState.from_json` in `zendriver/cdp/network.py` to accept both the old and new key name, maintaining backward compatibility with older Chrome versions.

Fixes https://github.com/cdpdriver/zendriver/issues/249

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass. (93 passed, 1 pre-existing failure in `test_keyinputs.py::test_visible_events[headless1]` — unrelated to this change.)
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
