### PR TITLE
Fix(tutorial): Flaky tutorial test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix flakey behavior in `api-reponses-2` tutorial @S-Tarr
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix flakey behavior in `api-reponses-2` tutorial @S-Tarr
+- Fix flakey behavior in `api-reponses-tutorial-2` tutorial @S-Tarr
 
 ### Added
 

--- a/docs/tutorials/tutorial-code/api-responses-2.py
+++ b/docs/tutorials/tutorial-code/api-responses-2.py
@@ -13,11 +13,8 @@ async def main() -> None:
         await page.get(
             "https://cdpdriver.github.io/examples/api-request.html",
         )
-        response = await response_expectation.value
-
-    request_id = response.request_id
-    body, _ = await page.send(get_response_body(request_id=request_id))
-    user_data = json.loads(body)
+        body, _ = await response_expectation.response_body
+        user_data = json.loads(body)
 
     print("Successfully read user data response for user:", user_data["name"])
     print(json.dumps(user_data, indent=2))


### PR DESCRIPTION
## Description

<!-- Please describe your change below this line -->
The `api-responses-tutorial-2` test has been failing in the Ubuntu actions tests almost every run with the output:
```
FAILED tests/docs/tutorials/test_api_responses_tutorial.py::test_api_responses_tutorial_2[headless0] - zendriver.core.connection.ProtocolException: No data found for resource with given identifier
command:Network.getResponseBody
```
 Looking into the issue, it seems that `response = await response_expectation.value` only guarantees the headers are available, so on slow systems running headless it's possible that attempt to get the response body afterward will fail. I made a small change to make sure it waits for the response body to be ready before trying to get it.
 
There's still some more tests flaking with different issues but they are much rarer and I haven't been able to reproduce them  locally.

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [X] I have described my change in the section above.
- [X] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [X] I have ran `uv run pytest` and ensured all tests pass.
- [X] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
