### PR TITLE
Fix SyntaxError on Python 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `SyntaxError` on Python 3.14 in `Connection._register_handlers`. PEP 765 makes `continue`/`break`/`return` that exits a `finally` block a `SyntaxError` (was a `SyntaxWarning` in 3.13), so `zendriver/core/connection.py` failed to import under 3.14. Removed the no-op `finally: continue` (the loop already falls through to the next iteration, and the enclosing bare `except:` catches everything, so nothing changed behaviorally). Fixes #252
+
 ### Added
 
 ### Changed

--- a/zendriver/core/connection.py
+++ b/zendriver/core/connection.py
@@ -632,8 +632,6 @@ class Connection(metaclass=CantTouchThis):
                     except:  # noqa
                         logger.debug("NOT GOOD", exc_info=True)
                         continue
-                finally:
-                    continue
         for ed in enabled_domains:
             # we started with a copy of self.enabled_domains and removed a domain from this
             # temp variable when we registered it or saw handlers for it.


### PR DESCRIPTION
PEP 765 makes control flow that exits a 'finally' block a SyntaxError in Python 3.14 (was SyntaxWarning in 3.13).

Fixes #252.

(If this PR lgty please auto-merge it.)

## Description

<!-- Please describe your change below this line -->

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
