### PR TITLE
fix: allow verify_cf() to click turnstile checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `verify_cf()` never clicking the Turnstile checkbox on Turnstile markup where the `cf-turnstile-response`/`cf_challenge_response` input is rendered as a document-level sibling of the challenge's shadow-DOM host rather than nested inside it. The lookup was scoped to `host_element`, always found nothing, and `verify_cf()` returned before ever calling `mouse_click`. Now queries the input from the document (`tab.query_selector`) instead. @A-Nolan
+
 ### Added
 
 ### Changed

--- a/tests/core/test_cloudflare.py
+++ b/tests/core/test_cloudflare.py
@@ -1,0 +1,95 @@
+from typing import Any
+
+import pytest
+
+import zendriver as zd
+from zendriver.core import cloudflare as cloudflare_module
+
+
+class _FakeInputElement:
+    def __init__(self) -> None:
+        self.attrs: dict[str, str] = {}
+
+    async def update(self) -> "_FakeInputElement":
+        return self
+
+    def __await__(self) -> Any:
+        return self.update().__await__()
+
+
+class _FakeChallengeIframe:
+    def __init__(self, node_id: int) -> None:
+        self.node = zd.cdp.dom.Node(
+            node_id=zd.cdp.dom.NodeId(node_id),
+            backend_node_id=zd.cdp.dom.BackendNodeId(node_id),
+            node_type=1,
+            node_name="IFRAME",
+            local_name="iframe",
+            node_value="",
+        )
+
+    async def scroll_into_view(self) -> None:
+        pass
+
+
+class _HostElementNeverQueried:
+    async def query_selector(self, selector: str) -> None:
+        raise AssertionError(
+            "verify_cf() queried the shadow host for the response input; "
+            "it should query the document (tab.query_selector) instead"
+        )
+
+
+async def test_verify_cf_clicks_checkbox_when_input_is_document_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    challenge_iframe = _FakeChallengeIframe(node_id=42)
+
+    async def fake_wait_for_challenge(
+        _tab: zd.Tab, _timeout: float
+    ) -> tuple[Any, Any, Any]:
+        return _HostElementNeverQueried(), object(), challenge_iframe
+
+    monkeypatch.setattr(
+        cloudflare_module,
+        "cf_wait_for_interactive_challenge",
+        fake_wait_for_challenge,
+    )
+
+    box_model = zd.cdp.dom.BoxModel(
+        content=zd.cdp.dom.Quad([0.0, 0.0, 100.0, 0.0, 100.0, 50.0, 0.0, 50.0]),
+        padding=zd.cdp.dom.Quad([]),
+        border=zd.cdp.dom.Quad([]),
+        margin=zd.cdp.dom.Quad([]),
+        width=100,
+        height=50,
+    )
+
+    async def fake_send(cdp_obj: Any, _is_update: bool = False) -> Any:
+        next(cdp_obj)
+        return box_model
+
+    tab = zd.Tab.__new__(zd.Tab)
+    monkeypatch.setattr(tab, "send", fake_send)
+
+    input_element = _FakeInputElement()
+    query_selector_calls: list[str] = []
+
+    async def fake_query_selector(selector: str) -> _FakeInputElement | None:
+        query_selector_calls.append(selector)
+        return input_element
+
+    monkeypatch.setattr(tab, "query_selector", fake_query_selector)
+
+    click_calls: list[tuple[float, float]] = []
+
+    async def fake_mouse_click(x: float, y: float) -> None:
+        click_calls.append((x, y))
+        input_element.attrs["value"] = "solved"
+
+    monkeypatch.setattr(tab, "mouse_click", fake_mouse_click)
+
+    await cloudflare_module.verify_cf(tab, click_delay=0, timeout=5)
+
+    assert click_calls, "verify_cf() never clicked the checkbox"
+    assert query_selector_calls[0] == "input[name=cf-turnstile-response]"

--- a/zendriver/core/cloudflare.py
+++ b/zendriver/core/cloudflare.py
@@ -217,11 +217,12 @@ async def verify_cf(
         if challenge_selector
         else "input[name=cf-turnstile-response]"
     )
-    input_element = await host_element.query_selector(current_selector)
+
+    input_element = await tab.query_selector(current_selector)
 
     if not input_element and not challenge_selector:
         current_selector = "input[name=cf_challenge_response]"
-        input_element = await host_element.query_selector(current_selector)
+        input_element = await tab.query_selector(current_selector)
 
     if not input_element:
         return
@@ -229,14 +230,14 @@ async def verify_cf(
     checkbox_clicked = False
 
     async def check_input(
-        input_el: Element, current_sltr: str, host_el: Element, ckbx_clckd: bool
+        input_el: Element, current_sltr: str, ckbx_clckd: bool
     ) -> bool:
         """Checks if the input element is still present and without a value."""
         if not input_el:
             return False
         try:
             await input_el
-            fresh_input = await host_el.query_selector(current_sltr)
+            fresh_input = await tab.query_selector(current_sltr)
         except Exception as e:
             raise Exception(f"Error checking input element: {e}.")
         if (input_el.attrs.get("value") or not fresh_input) and ckbx_clckd:
@@ -248,7 +249,6 @@ async def verify_cf(
     while await check_input(
         input_el=input_element,
         current_sltr=current_selector,
-        host_el=host_element,
         ckbx_clckd=checkbox_clicked,
     ):
         if loop.time() - start_time >= timeout:


### PR DESCRIPTION
## Description
Fixes #270 

`verify_cf()` silently no-ops on some Turnstile checkbox challenges: it correctly finds and measures the challenge iframe, but never actually clicks it. On real-world Turnstile markup, the hidden `cf-turnstile-response/cf_challenge_response <input>` that `verify_cf()` uses to detect "has the checkbox already been solved" is rendered as a document-level sibling of the challenge's shadow-DOM host, not nested inside it. The lookup was scoped to `host_element.query_selector(...)`, which always came back empty in that case, so the function hit if not input_element: return and exited before ever reaching the click loop

Fixes this by querying the input from tab (the whole document) instead of `host_element`, at both call sites (the initial lookup and the completion check inside `check_input()`). Verified live against cardmarket.com: the checkbox is now clicked and the challenge clears.

## Pre-merge Checklist
- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.