### PR TITLE
fix: set the lang browser flag from Config instead of add_argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `ValueError` on startup when the `lang` option is set @bercedev
+
 ### Added
 
 ### Changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ class CreateBrowser(AbstractAsyncContextManager):  # type: ignore
         browser_args: list[str] | None = None,
         browser_connection_max_tries: int = 15,
         browser_connection_timeout: float = 3.0,
+        lang: str | None = None,
     ):
         args = []
         if not headless and TestConfig.USE_WAYLAND:
@@ -67,6 +68,7 @@ class CreateBrowser(AbstractAsyncContextManager):  # type: ignore
             browser_args=args,
             browser_connection_max_tries=browser_connection_max_tries,
             browser_connection_timeout=browser_connection_timeout,
+            lang=lang,
         )
 
         self.browser: zd.Browser | None = None

--- a/tests/core/test_browser.py
+++ b/tests/core/test_browser.py
@@ -160,3 +160,13 @@ async def test_cookies_save_and_load_round_trip(
 
     restored = {cookie.name: cookie.value for cookie in await browser.cookies.get_all()}
     assert restored.get("kept") == "yes"
+
+
+async def test_browser_starts_with_lang_option(
+    create_browser: type[CreateBrowser],
+) -> None:
+    """Setting `lang` used to raise ValueError from Browser.start (#262)."""
+    async with create_browser(lang="de-DE") as browser:
+        assert "--lang=de-DE" in browser.config()
+        page = await browser.get("about:blank")
+        assert await page.evaluate("1 + 1") == 2

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,40 @@
+import zendriver as zd
+
+# The path is never executed, it only has to be set so that Config does not try to
+# autodetect a browser binary on machines that do not have one installed.
+FAKE_BROWSER_PATH = "/path/to/browser"
+
+
+def test_lang_is_added_to_browser_args() -> None:
+    config = zd.Config(browser_executable_path=FAKE_BROWSER_PATH, lang="de-DE")
+
+    assert "--lang=de-DE" in config()
+
+
+def test_lang_is_omitted_when_unset() -> None:
+    config = zd.Config(browser_executable_path=FAKE_BROWSER_PATH)
+
+    assert not any(arg.startswith("--lang=") for arg in config())
+
+
+def test_lang_can_be_combined_with_other_browser_args() -> None:
+    config = zd.Config(
+        browser_executable_path=FAKE_BROWSER_PATH,
+        lang="fr-FR",
+        browser_args=["--mute-audio"],
+    )
+    args = config()
+
+    assert "--lang=fr-FR" in args
+    assert "--mute-audio" in args
+
+
+def test_add_argument_still_rejects_lang() -> None:
+    """`lang` remains an attribute-only setting, it is not set through add_argument."""
+    config = zd.Config(browser_executable_path=FAKE_BROWSER_PATH)
+
+    try:
+        config.add_argument("--lang=de-DE")
+    except ValueError:
+        return
+    raise AssertionError("add_argument should reject --lang")

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -358,9 +358,6 @@ class Browser:
                 % ",".join(str(_) for _ in self.config._extensions)
             )  # noqa
 
-        if self.config.lang is not None:
-            self.config.add_argument(f"--lang={self.config.lang}")
-
         exe = self.config.browser_executable_path
         params = self.config()
         params.append("about:blank")

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -212,6 +212,8 @@ class Config:
             args.append("--headless=new")
         if self.user_agent:
             args.append(f"--user-agent={self.user_agent}")
+        if self.lang:
+            args.append(f"--lang={self.lang}")
         if not self.sandbox:
             args.append("--no-sandbox")
         if self.host:


### PR DESCRIPTION
Closes #262.

## The problem

`Browser.start` appends the flag through `Config.add_argument`:

```python
# zendriver/core/browser.py
if self.config.lang is not None:
    self.config.add_argument(f"--lang={self.config.lang}")
```

but `add_argument` rejects any argument containing `"lang"`:

```python
# zendriver/core/config.py
def add_argument(self, arg: str) -> None:
    if any(x in arg.lower() for x in ["headless", "data-dir", "data_dir", "no-sandbox", "no_sandbox", "lang"]):
        raise ValueError(
            '"%s" not allowed. please use one of the attributes of the Config object to set it' % arg
        )
```

So setting the attribute the error message points to is exactly what triggers the error. `lang` is unusable through every entry point:

```python
import asyncio
import zendriver as zd

async def main():
    browser = await zd.start(lang="en-US")
    await browser.stop()

asyncio.run(main())
```

```
  File "zendriver/core/browser.py", line 362, in start
    self.config.add_argument(f"--lang={self.config.lang}")
  File "zendriver/core/config.py", line 243, in add_argument
    raise ValueError(...)
ValueError: "--lang=en-US" not allowed. please use one of the attributes of the Config object to set it
```

Same for `Browser.create(lang=...)` and `Config(lang=...)`. The only way to get the flag through today is to bypass the attribute entirely — `Config(browser_args=["--lang=en-US"])` works, because arguments passed to the constructor are not validated.

## The fix

Emit the flag from `Config.__call__`, next to the other attribute-backed flags:

```python
if self.user_agent:
    args.append(f"--user-agent={self.user_agent}")
if self.lang:
    args.append(f"--lang={self.lang}")
if not self.sandbox:
    args.append("--no-sandbox")
```

and drop the `add_argument` call from `Browser.start`. This matches how `headless`, `user_agent` and `sandbox` are already handled, keeps the `add_argument` guard intact, and needs no new API.

## Tests

- `tests/core/test_config.py` (new): the flag is emitted when `lang` is set, omitted when it is not, composes with `browser_args`, and `add_argument("--lang=…")` still raises.
- `tests/core/test_browser.py`: a browser actually starts with `lang` set — this is the regression that produced the `ValueError`.
- `tests/conftest.py`: `CreateBrowser` accepts `lang` so the test above can pass it.

Verified with `scripts/lint.sh` (ruff + mypy clean) and the tests above on Chromium 151.

## Note

Worth flagging separately: `--lang` does not change `navigator.language`, which keeps reporting the browser's installed UI language. That is Chromium behaviour rather than something this PR changes, so I left it alone — happy to open a separate issue if you would like it documented.
